### PR TITLE
Switch all database.run_pipeline() calls to database.run_pipeline_cur…

### DIFF
--- a/cyhy/db/scheduler.py
+++ b/cyhy/db/scheduler.py
@@ -99,7 +99,7 @@ class DefaultScheduler(BaseScheduler):
     def __host_max_severity(self, host):
         ip_int = host['_id']
         q = max_severity_for_host(ip_int)
-        r = database.run_pipeline(q, self._db)
+        r = database.run_pipeline_cursor(q, self._db)
         database.id_expand(r)
         if len(r) > 0:
             # found tickets

--- a/cyhy/db/ticket_manager.py
+++ b/cyhy/db/ticket_manager.py
@@ -187,7 +187,7 @@ class VulnTicketManager(object):
         #                                     'open':True})
         
         # work-around using a pipeline
-        tickets = database.run_pipeline(
+        tickets = database.run_pipeline_cursor(
             close_tickets_pl(ip_ints, list(self.__ports), list(self.__source_ids), list(self.__seen_ticket_ids), self.__source),
                              self.__db)
         
@@ -212,7 +212,7 @@ class VulnTicketManager(object):
         '''clear the latest flag for vuln_docs that match the ticket_manager scope'''
         ip_ints = [int(i) for i in self.__ips]
         pipeline = clear_latest_vulns_pl(ip_ints, list(self.__ports), list(self.__source_ids),  self.__source)
-        raw_vulns = database.run_pipeline(pipeline, self.__db)
+        raw_vulns = database.run_pipeline_cursor(pipeline, self.__db)
         for raw_vuln in raw_vulns:
             vuln = self.__db.VulnScanDoc(raw_vuln)
             vuln['latest'] = False


### PR DESCRIPTION
…sor() to comply with this change in mongo 3.6:

  https://docs.mongodb.com/manual/release-notes/3.4-compatibility/#aggregate-without-cursor