### PR TITLE
Include ipython in setup for operational script debugging purposes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get install -y mongodb-org-shell
 WORKDIR ${CYHY_CORE_SRC}
 
 COPY . ${CYHY_CORE_SRC}
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir .[dev]
 RUN var/geoipupdate.sh
 RUN ln -snf ${CYHY_CORE_SRC}/var/getenv /usr/local/bin
 RUN ln -snf ${CYHY_CORE_SRC}/var/getopsenv /usr/local/bin

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,12 @@ setup(
         "docopt >= 0.6.2",
         "pandas >= 0.16.2",  # TODO: test with 0.19.1
         "six >= 1.9",
-        "mock >= 2.0.0",
-        "PyYAML >= 3.12",
-        "ipython >= 5.4.0"
-    ]
+        "PyYAML >= 3.12"
+    ],
+    extras_require={
+        'dev': [
+            "mock >= 2.0.0",
+            'ipython >= 5.8.0'
+        ],
+    },
 )


### PR DESCRIPTION
Adding this in as a convenience for Ops team members that want to create/test/debug one-off Python scripts within their Docker containers