### PR TITLE
Remove __manual_scan checks that were mistakenly added

### DIFF
--- a/cyhy/db/ticket_manager.py
+++ b/cyhy/db/ticket_manager.py
@@ -364,8 +364,6 @@ class IPPortTicketManager(object):
                     "reference": None,
                     "delta": [{"from": True, "to": False, "key": "false_positive"}],
                 }
-                if self.__manual_scan:
-                    event["manual"] = True
                 ticket["events"].append(event)
 
     def __handle_ticket_port_closed(self, ticket, closing_time):
@@ -390,8 +388,6 @@ class IPPortTicketManager(object):
                 "reason": reason,
                 "reference": None,
             }
-        if self.__manual_scan:
-            event["manual"] = True
         ticket["events"].append(event)
         ticket.save()
 
@@ -492,8 +488,6 @@ class IPTicketManager(object):
                     "reference": None,
                     "delta": [{"from": True, "to": False, "key": "false_positive"}],
                 }
-                if self.__manual_scan:
-                    event["manual"] = True
                 ticket["events"].append(event)
 
     def close_tickets(self, closing_time=None):
@@ -529,8 +523,6 @@ class IPTicketManager(object):
                     "reason": reason,
                     "reference": None,
                 }
-            if self.__manual_scan:
-                event["manual"] = True
             ticket["events"].append(event)
             ticket.save()
 


### PR DESCRIPTION
We added `__manual_scan` checks outside of the `VulnTicketManager`.  This was a mistake.   This PR removes those checks.  

This caused errors in the commander's log that looked like: 
```
2019-06-17 14:16:22,795 INFO cyhy_commander.commander - Processing done/PORTSCAN-20190617T125738.655688+0000 with <NmapSink PORTSCAN Database(MongoClient('database1.cyhy', 27017), u'cyhy')>
2019-06-17 14:16:22,883 CRITICAL cyhy_commander.commander - 'IPPortTicketManager' object has no attribute '_IPPortTicketManager__manual_scan'
2019-06-17 14:16:22,883 CRITICAL cyhy_commander.commander - Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/commander.py", line 451, in do_work
    execute(self.__done_jobs, self, hosts=hosts)
  File "/usr/local/lib/python2.7/dist-packages/fabric/tasks.py", line 386, in execute
    multiprocessing
  File "/usr/local/lib/python2.7/dist-packages/fabric/tasks.py", line 276, in _execute
    return task.run(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/fabric/tasks.py", line 173, in run
    return self.wrapped(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/commander.py", line 216, in __done_jobs
    self.__process_successful_job(local_job_path)
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/commander.py", line 312, in __process_successful_job
    sink.handle(job_path)
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/job_sink.py", line 31, in handle
    importer.process(nmap_output_file, target_file)
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/nmap/nmap_importer.py", line 48, in process
    parse(f, self.handler)
  File "/usr/lib/python2.7/xml/sax/__init__.py", line 33, in parse
    parser.parse(source)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 110, in parse
    xmlreader.IncrementalParser.parse(self, source)
  File "/usr/lib/python2.7/xml/sax/xmlreader.py", line 123, in parse
    self.feed(buffer)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 213, in feed
    self._parser.Parse(data, isFinal)
  File "/usr/lib/python2.7/xml/sax/expatreader.py", line 320, in end_element
    self._cont_handler.endElement(name)
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/nmap/nmap_handler.py", line 85, in endElement
    self.end_callback()
  File "/usr/local/lib/python2.7/dist-packages/cyhy_commander/nmap/nmap_importer.py", line 131, in __end_callback
    self.__ticket_manager.close_tickets()
  File "/usr/local/lib/python2.7/dist-packages/cyhy/db/ticket_manager.py", line 445, in close_tickets
    self.__handle_ticket_port_closed(ticket, closing_time)
  File "/usr/local/lib/python2.7/dist-packages/cyhy/db/ticket_manager.py", line 393, in __handle_ticket_port_closed
    if self.__manual_scan:
AttributeError: 'IPPortTicketManager' object has no attribute '_IPPortTicketManager__manual_scan'```
