### PR TITLE
Fix gnis import

### DIFF
--- a/var/GNIS_data_import.py
+++ b/var/GNIS_data_import.py
@@ -41,7 +41,7 @@ def is_imported(db, f, type):
     This check is done by seeing if the first and last records are already in
     the database.
     NOTE: This method is entirely reliant on Python 2 file reading behavior.
-     """
+    """
     # GOVT_UNITS
     if type == 0:
         header = GOVT_UNITS_HEADER


### PR DESCRIPTION
This PR would alter the way the script checks if a provided CSV is already loaded as well as allowing the option to force load a file. It simply checks if both the first and last records in the CSV are already loaded. If they are it exits, otherwise it will continue loading. If the --force flag is passed it will not check anything and simply load the provided file into the database.