### PR TITLE
Catch AddressNotFoundError from GeoIP2 lookup and return an appropriate value.

### DIFF
--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 import geoip2.database
+from geoip2.errors import AddressNotFoundError
 
 GEODB_FILE = "GeoIP2-City.mmdb"
 GEODB_CITY_PATHS = ["/usr/share/GeoIP/", "/usr/local/share/GeoIP/"]
@@ -25,8 +26,11 @@ class GeoLocDB(object):
         self.__reader = geoip2.database.Reader(database_path)
 
     def lookup(self, ip):
-        # ip is expected to be a netaddr.IPAddress
-        response = self.__reader.city(str(ip))
-        if response == None:
+        try:
+            # ip is expected to be a netaddr.IPAddress
+            response = self.__reader.city(str(ip))
+            if response == None:
+                return (None, None)
+            return (response.location.longitude, response.location.latitude)
+        except AddressNotFoundError:
             return (None, None)
-        return (response.location.longitude, response.location.latitude)


### PR DESCRIPTION
This PR updates GeoLocDB to nicely handle if an address is not found in the GeoIP2 database.