### PR TITLE
Allow for more than two POCs in the cyhy-simple script

### DIFF
--- a/bin/cyhy-simple
+++ b/bin/cyhy-simple
@@ -212,7 +212,7 @@ def fill_in(db, filename, force=False):
 
 
 def main():
-    args = docopt(__doc__, version="v0.0.1")
+    args = docopt(__doc__, version="v0.0.2")
 
     if args["--blank"]:
         write_blank_config()


### PR DESCRIPTION
This is in response to a request from @climber-girl, who tires of manually adding extra POCs to the request JSON after running `cyhy-simple`.  This simple change will save the CyHy team a lot of time and suffering.

I recommend viewing the commits separately when reviewing.  The commit a3ef3d2 contains the actual code changes I made, while the commit 275a22f contains the changes made by the Python code linter [black](https://github.com/psf/black).

(I went ahead and [blackened the `cyhy-simple` script like a piece of redfish](https://www.newyorker.com/culture/culture-desk/postcript-paul-prudhomme-1940-2015), since that will make @felddy's upcoming merge of #36 slightly simpler.)