### PR TITLE
Pin maxminddb Version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     install_requires=[
         "docopt >= 0.6.2",
         "geoip2 >= 2.3.0",
+        "maxminddb <2.0.0",
         "mongokit >= 0.9.0",
         "netaddr >= 0.7.10",
         "pandas >= 0.16.2",  # TODO: test with 0.19.1


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR pins the version of [maxminddb](https://github.com/maxmind/MaxMind-DB-Reader-python) to <v2.0.0.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context

After redeploying the dashboard instance I found that it was unable to connect to the database to retrieve data. When I looked into the logs I found that there was an error in `cyhy.core.geoloc` as a result of the [maxminddb](https://github.com/maxmind/MaxMind-DB-Reader-python) library used by the [geoip2](https://github.com/maxmind/GeoIP2-python) package. Version 2.0.0 was released yesterday, and this version breaks compatibility with Python <3.6. The version of [geoip2](https://github.com/maxmind/GeoIP2-python) that we install only has the pin `maxminddb>=1.5.2`, so an incompatible version was being installed on our Python 2.7 images.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

The dashboard was able to operate as expected once I rebuilt the image with this branch's code and redeployed.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
