### PR TITLE
Deconflict organization types

### DIFF
--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1264,18 +1264,16 @@ class RequestDoc(RootDoc):
     ):
         """returns a dict of types to owners.  The owners can be in a set or list depending on "as_lists" parameter.
            "stakeholders_only" parameter eliminates non-stakeholders from the dict."""
-        types = dict()
-        for agency_type in AGENCY_TYPE:
-            types[agency_type] = set()
-            all_agency_type_descendants = self.get_all_descendants(
-                agency_type, include_retired=include_retired
-            )
-            if stakeholders_only:
-                for org in self.find({"_id": {"$in": all_agency_type_descendants}}):
-                    if org["stakeholder"]:
-                        types[agency_type].add(org["_id"])
-            else:
-                types[agency_type] = set(all_agency_type_descendants)
+        types = defaultdict(lambda: set())
+
+        # No need to reinvent the wheel here- call get_owner_to_type_dict()
+        # and then rearrange the data a bit.
+        owner_to_type = get_owner_to_type_dict(
+            stakeholders_only=stakeholders_only, include_retired=include_retired
+        )
+        for org_id, org_type in owner_to_type.iteritems():
+            types[org_type].add(org_id)
+
         # convert to a dict of lists
         if not as_lists:
             return types

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1,6 +1,6 @@
 __all__ = ["db_from_connection", "db_from_config", "id_expand", "ensure_indices"]
 
-from collections import OrderedDict, Iterable
+from collections import defaultdict, Iterable, OrderedDict
 import copy
 import datetime
 import random
@@ -1213,7 +1213,7 @@ class RequestDoc(RootDoc):
 
     def get_owner_to_type_dict(self, stakeholders_only=False, include_retired=False):
         """returns a dict of owner_id:type. "stakeholders_only" parameter eliminates non-stakeholders from the dict."""
-        types = dict()
+        types = defaultdict(lambda: list())
         for agency_type in AGENCY_TYPE:
             all_agency_type_descendants = self.get_all_descendants(
                 agency_type, include_retired=include_retired
@@ -1221,9 +1221,9 @@ class RequestDoc(RootDoc):
             for org in self.find({"_id": {"$in": all_agency_type_descendants}}):
                 if stakeholders_only:
                     if org["stakeholder"]:
-                        types[org["_id"]] = agency_type
+                        types[org["_id"]].append(agency_type)
                 else:
-                    types[org["_id"]] = agency_type
+                    types[org["_id"]].append(agency_type)
         return types
 
     def get_owner_types(

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1265,7 +1265,7 @@ class RequestDoc(RootDoc):
 
         # No need to reinvent the wheel here- call get_owner_to_type_dict()
         # and then rearrange the data a bit.
-        owner_to_type = get_owner_to_type_dict(
+        owner_to_type = self.get_owner_to_type_dict(
             stakeholders_only=stakeholders_only, include_retired=include_retired
         )
         for org_id, org_type in owner_to_type.iteritems():

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1219,10 +1219,7 @@ class RequestDoc(RootDoc):
                 agency_type, include_retired=include_retired
             )
             for org in self.find({"_id": {"$in": all_agency_type_descendants}}):
-                if stakeholders_only:
-                    if org["stakeholder"]:
-                        types[org["_id"]].append(agency_type)
-                else:
+                if not stakeholders_only or org["stakeholder"]:
                     types[org["_id"]].append(agency_type)
 
         # Check for any orgs that fall into multiple types.  This can occur


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR updates two functions (`get_owner_to_type_dict` and `get_owner_types`) so that each organization in the results is only assigned to a single "type" (`FEDERAL`, `STATE`, `LOCAL`, `PRIVATE`, `TRIBAL`, `TERRITORIAL`).

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
The primary reason for this change is specified in CYHYDEV-789.  We realized that by creating orgs that have the `CYHY_THIRD_PARTY` reporting type, it became possible to have a legitimate situation where an organization was a descendant of multiple type nodes (most commonly, both `LOCAL` for the org itself and `PRIVATE` for the third party).

The solution implemented here favors the organization's direct parent node (e.g. `LOCAL`) over any other ancestors (e.g. the third party report organization's parent node).

If an organization is (usually erroneously) set up as a child of more than one parent type (e.g. both `FEDERAL` and `STATE`), this code will now report the type of that organization as `FEDERAL_STATE` in the hopes that a human will notice this anomaly and correct the situation.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I manually tested these updated functions in a Python shell and validated that they work as expected.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
