### PR TITLE
Prevent unicode characters on import

### DIFF
--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -119,9 +119,14 @@ def import_request(db, request, source, force=False, init_stage=None):
 
 
 def import_file(db, filename, force, init_stage=None):
-    f = open(filename, "rb")
-    request = json.load(f)
-    f.close()
+    try:
+        with open(filename, "r") as f:
+            # For py3, encoding should move from json.load into open statement
+            request = json.load(f, encoding="ascii")
+    except UnicodeDecodeError as e:
+        print ("Document contained a non-ASCII character: {}".format(e))
+        return False
+
     return import_request(db, request, filename, force, init_stage)
 
 

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -124,7 +124,7 @@ def import_file(db, filename, force, init_stage=None):
             # For py3, encoding should move from json.load into open statement
             request = json.load(f, encoding="ascii")
     except UnicodeDecodeError as e:
-        print ("Document contained a non-ASCII character: {}".format(e))
+        print ("Document contains a non-ASCII character: {}".format(e))
         return False
 
     return import_request(db, request, filename, force, init_stage)


### PR DESCRIPTION
Adds a check for unicode characters when importing a file to prevent putting non-ASCII characters in the database.

Closes #48 .

## 🗣 Description

- Adds a try/except block and forces encoding to be ASCII
- Adds a note for a small change when going py2->py3

## 💭 Motivation and Context

Prevents non-ASCII unicode characters from making it into the database and causing issues.

## 🧪 Testing

Tested on the command line in py2 against a known-bad import doc and it successfully alerts the user:

```console
Document contained a non-ASCII character: 'ascii' codec can't decode byte 0xe2 
in position 44: ordinal not in range(128)
```

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
