### PR TITLE
Change Dockerfile base image to Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM python:2-stretch
-LABEL maintainer="Mark Feldhousen <mark.feldhousen@hq.dhs.gov>"
+# NOTE: Be careful- you really don't want to push this Docker image to the
+# public Docker Hub if it was built with your MaxMind license key!
+
+FROM debian:stretch-slim
+LABEL maintainer="Mark Feldhousen <mark.feldhousen@cisa.dhs.gov>"
 LABEL description="Docker image to provide tools for interacting with the CyHy \
 production database."
 ENV CYHY_HOME="/home/cyhy" \
@@ -15,12 +18,16 @@ RUN mkdir ${CYHY_HOME}
 RUN chown cyhy:cyhy ${CYHY_HOME}
 VOLUME ${CYHY_ETC} ${CYHY_HOME}
 
+RUN apt-get update && apt-get install -y \
+   gnupg \
+   python-dev \
+   python-pip
+
 # Install MongoDB shell from official repository
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
 RUN echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main" | tee /etc/apt/sources.list.d/mongodb-org-4.0.list
 RUN echo "deb http://ftp.debian.org/debian stretch-backports main" | tee /etc/apt/sources.list.d/stretch-backports.list
-RUN apt-get update
-RUN apt-get install -y mongodb-org-shell
+RUN apt-get update && apt-get install -y mongodb-org-shell
 
 WORKDIR ${CYHY_CORE_SRC}
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The CyHy commands implemented in the docker container can be aliased into the ho
 
 Alias the container commands to the local environment:
 ```bash
-eval "$(docker run cisa/cyhy-core)"
+eval "$(docker run cisagov/cyhy-core)"
 ```
 
 To run a CyHy command:
@@ -51,12 +51,12 @@ Whenever an aliased CyHy command is executed, it will use the current working di
 
 ### Advanced configuration
 
-By default, the container will look for your CyHy configurations in `/etc/cyhy`.  This location can be changed by setting the `CYHY_CONF_DIR` environment variable to point to your CyHy configuration directory.  The commands will also attempt to run using the `cisa/cyhy-core` image.  A different image can be used by setting the `CYHY_CORE_IMAGE` environment variable to the image name.
+By default, the container will look for your CyHy configurations in `/etc/cyhy`.  This location can be changed by setting the `CYHY_CONF_DIR` environment variable to point to your CyHy configuration directory.  The commands will also attempt to run using the `cisagov/cyhy-core` image.  A different image can be used by setting the `CYHY_CORE_IMAGE` environment variable to the image name.
 
 Example:
 ```
 export CYHY_CONF_DIR=/private/etc/cyhy
-export CYHY_CORE_IMAGE=dhub.ncats.dhs.gov:5001/cyhy-core
+export CYHY_CORE_IMAGE=cisagov/cyhy-core
 ```
 
 ### Building the cyhy-core container
@@ -69,21 +69,24 @@ The following commands show how to build the Docker container for cyhy-core.
 
 #### No MaxMind license
 ```console
-docker build --tag cisa/cyhy-core .
+docker build --tag cisagov/cyhy-core .
 ```
 
 #### MaxMind GeoLite2 license
 ```console
-docker build --tag cisa/cyhy-core \
+docker build --tag cisagov/cyhy-core \
              --build-arg maxmind_license_key=<license key> .
 ```
 
 #### MaxMind GeoIP2 license
 ```console
-docker build --tag cisa/cyhy-core \
+docker build --tag cisagov/cyhy-core \
              --build-arg maxmind_license_type="full" \
              --build-arg maxmind_license_key=<license key> .
 ```
+
+**WARNING: Be careful- you really don't want to push a Docker image to the
+public Docker Hub if it was built with your MaxMind license key!**
 
 ### Building a cyhy-core image for distribution
 The helper script `generate_cyhy_docker_image.sh` can be used to automate
@@ -91,7 +94,7 @@ building and saving a Docker image. It requires a file named
 `maxmind_license.txt` that contains the MaxMind GeoIP2 license. It can be run
 without arguments, with the default image name and a specified tag, or with a
 specified image name and tag. The default configuration is
-`cisa/cyhy-core:latest`.
+`cisagov/cyhy-core:latest`.
 
 #### Default name and tag
 ```console
@@ -105,7 +108,7 @@ specified image name and tag. The default configuration is
 
 #### Specified name and tag
 ```console
-./generate_cyhy_docker_image.sh cisa/cyhy-core testing
+./generate_cyhy_docker_image.sh cisagov/cyhy-core testing
 ```
 
 ## Manual Installation

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Whenever an aliased CyHy command is executed, it will use the current working di
 By default, the container will look for your CyHy configurations in `/etc/cyhy`.  This location can be changed by setting the `CYHY_CONF_DIR` environment variable to point to your CyHy configuration directory.  The commands will also attempt to run using the `cisagov/cyhy-core` image.  A different image can be used by setting the `CYHY_CORE_IMAGE` environment variable to the image name.
 
 Example:
-```
+```bash
 export CYHY_CONF_DIR=/private/etc/cyhy
 export CYHY_CORE_IMAGE=cisagov/cyhy-core
 ```

--- a/generate_cyhy_docker_image.sh
+++ b/generate_cyhy_docker_image.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-IMAGE_NAME="cisa/cyhy-core"
+IMAGE_NAME="cisagov/cyhy-core"
 IMAGE_TAG="latest"
 
 if [ $# -eq 1 ]

--- a/var/getenv
+++ b/var/getenv
@@ -3,11 +3,11 @@
 echo '################################################################################'
 echo '# The following output is used to setup aliases to containerized cyhy commands'
 echo '# To apply these changes under bash use a command similar to:'
-echo '# eval "$(docker run cisa/cyhy-core)"'
+echo '# eval "$(docker run cisagov/cyhy-core)"'
 echo '#'
 echo '# Environment variables:'
 echo '# CYHY_CONF_DIR, defaults to "/etc/cyhy" if not set'
-echo '# CYHY_CORE_IMAGE, defaults to "cisa/cyhy-core" if not set'
+echo '# CYHY_CORE_IMAGE, defaults to "cisagov/cyhy-core" if not set'
 echo '################################################################################'
 echo
 
@@ -16,8 +16,8 @@ cd /usr/local/bin
 # create output that can be evaled to create aliases for cyhy commands
 for f in cyhy-*
 do
-  echo alias $f=\"docker run -it --rm --volume \\\"\\\${CYHY_CONF_DIR:-/etc/cyhy}\\\":/etc/cyhy --volume \\\`pwd\\\`:/home/cyhy \\\"\\\${CYHY_CORE_IMAGE:-cisa/cyhy-core}\\\" $f\"
+  echo alias $f=\"docker run -it --rm --volume \\\"\\\${CYHY_CONF_DIR:-/etc/cyhy}\\\":/etc/cyhy --volume \\\`pwd\\\`:/home/cyhy \\\"\\\${CYHY_CORE_IMAGE:-cisagov/cyhy-core}\\\" $f\"
 done
 
 # create an alias to start bash in the container
-echo alias cyhy-bash=\"docker run -it --rm --volume \\\"\\\${CYHY_CONF_DIR:-/etc/cyhy}\\\":/etc/cyhy --volume \\\`pwd\\\`:/home/cyhy \\\"\\\${CYHY_CORE_IMAGE:-cisa/cyhy-core}\\\" /bin/bash\"
+echo alias cyhy-bash=\"docker run -it --rm --volume \\\"\\\${CYHY_CONF_DIR:-/etc/cyhy}\\\":/etc/cyhy --volume \\\`pwd\\\`:/home/cyhy \\\"\\\${CYHY_CORE_IMAGE:-cisagov/cyhy-core}\\\" /bin/bash\"


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR changes the base Docker image for `cyhy-core` from `python:2-stretch` to `debian:stretch-slim`.

I also cleaned up the README a bit, since it had some outdated Docker image name references.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
This change was done because the Docker image was no longer building correctly on `python:2-stretch`.  The path of least resistance was to move to creating the image on Debian, similar to how we install `cyhy-core` with [`ansible-role-cyhy-core`](https://github.com/cisagov/ansible-role-cyhy-core).

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
The Docker image builds successfully- what could possibly go wrong?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
