### PR TITLE
Improve the Docker Image Helper Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 .DS_Store
 .ipynb_checkpoints
 .python-version
-maxmind_license.txt

--- a/README.md
+++ b/README.md
@@ -90,11 +90,9 @@ public Docker Hub if it was built with your MaxMind license key!**
 
 ### Building a cyhy-core image for distribution
 The helper script `generate_cyhy_docker_image.sh` can be used to automate
-building and saving a Docker image. It requires a file named
-`maxmind_license.txt` that contains the MaxMind GeoIP2 license. It can be run
-without arguments, with the default image name and a specified tag, or with a
-specified image name and tag. The default configuration is
-`cisagov/cyhy-core:latest`.
+building and saving a Docker image. It can be run without arguments, with the
+default image name and a specified tag, or with a specified image name and tag.
+The default configuration is `cisagov/cyhy-core:latest`.
 
 #### Default name and tag
 ```console

--- a/README.md
+++ b/README.md
@@ -90,9 +90,20 @@ public Docker Hub if it was built with your MaxMind license key!**
 
 ### Building a cyhy-core image for distribution
 The helper script `generate_cyhy_docker_image.sh` can be used to automate
-building and saving a Docker image. It can be run without arguments, with the
-default image name and a specified tag, or with a specified image name and tag.
-The default configuration is `cisagov/cyhy-core:latest`.
+building and saving a Docker image.
+
+```console
+Usage:
+  generate_cyhy_docker_image.sh [options]
+
+Options:
+  -i, --image-name=NAME  Image name to use [default: cisagov/cyhy-core].
+  -t, --image-tag=TAG    Image tag to use [default: latest].
+  -h, --help             Display this message.
+
+Notes:
+- Requires Docker and the AWS CLI to run.
+```
 
 #### Default name and tag
 ```console

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Notes:
 
 #### Specified name and default tag
 ```console
-./generate_cyhy_docker_image.sh --image-name cisagove/cyhy-env
+./generate_cyhy_docker_image.sh --image-name cisagov/cyhy-env
 ```
 
 #### Default name and specified tag

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Usage:
   generate_cyhy_docker_image.sh [options]
 
 Options:
-  -i, --image-name=NAME  Image name to use [default: cisagov/cyhy-core].
-  -t, --image-tag=TAG    Image tag to use [default: latest].
+  -i, --image-name NAME  Image name to use [default: cisagov/cyhy-core].
+  -t, --image-tag TAG    Image tag to use [default: latest].
   -h, --help             Display this message.
 
 Notes:
@@ -110,14 +110,19 @@ Notes:
 ./generate_cyhy_docker_image.sh
 ```
 
+#### Specified name and default tag
+```console
+./generate_cyhy_docker_image.sh --image-name cisagove/cyhy-env
+```
+
 #### Default name and specified tag
 ```console
-./generate_cyhy_docker_image.sh testing
+./generate_cyhy_docker_image.sh  --image-tag testing
 ```
 
 #### Specified name and tag
 ```console
-./generate_cyhy_docker_image.sh cisagov/cyhy-core testing
+./generate_cyhy_docker_image.sh --image-name cisagov/cyhy-env --image-tag testing
 ```
 
 ## Manual Installation

--- a/generate_cyhy_docker_image.sh
+++ b/generate_cyhy_docker_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o nounset
 set -o errexit

--- a/generate_cyhy_docker_image.sh
+++ b/generate_cyhy_docker_image.sh
@@ -17,8 +17,14 @@ then
 fi
 
 IMAGE_OUTPUT_FILE="cisa_cyhy_core_docker_image_$(date +'%Y%m%d').tgz"
+MAXMIND_LICENSE_KEY=$(aws ssm get-parameter \
+                    --output text \
+                    --name "/cyhy/core/geoip/license_key" \
+                    --with-decryption \
+                    | awk -F"\t" '{print $6}')
+
 
 docker build --tag "$IMAGE_NAME:$IMAGE_TAG" \
              --build-arg maxmind_license_type="full" \
-             --build-arg maxmind_license_key="$(< maxmind_license.txt)" .
+             --build-arg maxmind_license_key="$MAXMIND_LICENSE_KEY" .
 docker save "$IMAGE_NAME:$IMAGE_TAG" | gzip > "$IMAGE_OUTPUT_FILE"

--- a/generate_cyhy_docker_image.sh
+++ b/generate_cyhy_docker_image.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+#
+# Generate a cyhy-core Docker image for distribution to the CyHy Team.
 
 set -o nounset
 set -o errexit
@@ -7,14 +9,67 @@ set -o pipefail
 IMAGE_NAME="cisagov/cyhy-core"
 IMAGE_TAG="latest"
 
-if [ $# -eq 1 ]
-then
-  IMAGE_TAG=$1
-elif [ $# -eq 2 ]
-then
-  IMAGE_NAME=$1
-  IMAGE_TAG=$2
-fi
+# Print usage information and exit with the provided exit code.
+function usage {
+  echo "Usage:"
+  echo "  ${0##*/} [options]"
+  echo
+  echo "Options:"
+  echo "  -i, --image-name=NAME  Image name to use [default: $IMAGE_NAME]."
+  echo "  -t, --image-tag=TAG    Image tag to use [default: $IMAGE_TAG]."
+  echo "  -h, --help             Display this message."
+  exit "$1"
+}
+
+# Check for required external programs. If any are missing output a list of all
+# requirements and then exit.
+function check_dependencies {
+  required_tools="aws docker"
+  for tool in $required_tools
+  do
+    if [ -z "$(command -v "$tool")" ]
+    then
+      echo "This script requires the following tools to run:"
+      for item in $required_tools
+      do
+        echo "- $item"
+      done
+      exit 1
+    fi
+  done
+}
+
+while (( "$#" ))
+do
+  case "$1" in
+    -h|--help)
+      usage 0
+      ;;
+    -n|--image-name)
+      if [ -n "$2" ] && [ "${2:0:1}" != "-" ]
+      then
+        IMAGE_NAME=$2
+        shift 2
+      else
+        usage 1
+      fi
+      ;;
+    -t|--image-tag)
+      if [ -n "$2" ] && [ "${2:0:1}" != "-" ]
+      then
+        IMAGE_TAG=$2
+        shift 2
+      else
+        usage 1
+      fi
+      ;;
+    -*)
+      usage 1
+      ;;
+  esac
+done
+
+check_dependencies
 
 IMAGE_OUTPUT_FILE="cisa_cyhy_core_docker_image_$(date +'%Y%m%d').tgz"
 MAXMIND_LICENSE_KEY=$(aws ssm get-parameter \

--- a/generate_cyhy_docker_image.sh
+++ b/generate_cyhy_docker_image.sh
@@ -15,8 +15,8 @@ function usage {
   echo "  ${0##*/} [options]"
   echo
   echo "Options:"
-  echo "  -i, --image-name=NAME  Image name to use [default: $IMAGE_NAME]."
-  echo "  -t, --image-tag=TAG    Image tag to use [default: $IMAGE_TAG]."
+  echo "  -i, --image-name NAME  Image name to use [default: $IMAGE_NAME]."
+  echo "  -t, --image-tag TAG    Image tag to use [default: $IMAGE_TAG]."
   echo "  -h, --help             Display this message."
   echo
   echo "Notes:"

--- a/generate_cyhy_docker_image.sh
+++ b/generate_cyhy_docker_image.sh
@@ -18,6 +18,9 @@ function usage {
   echo "  -i, --image-name=NAME  Image name to use [default: $IMAGE_NAME]."
   echo "  -t, --image-tag=TAG    Image tag to use [default: $IMAGE_TAG]."
   echo "  -h, --help             Display this message."
+  echo
+  echo "Notes:"
+  echo "- Requires Docker and the AWS CLI to run."
   exit "$1"
 }
 

--- a/generate_cyhy_docker_image.sh
+++ b/generate_cyhy_docker_image.sh
@@ -74,7 +74,8 @@ done
 
 check_dependencies
 
-IMAGE_OUTPUT_FILE="cisa_cyhy_core_docker_image_$(date +'%Y%m%d').tgz"
+BASE_IMAGE_NAME="$(echo "$IMAGE_NAME" | tr "/" "_")_$IMAGE_TAG"
+IMAGE_OUTPUT_FILE="${BASE_IMAGE_NAME}_$(date +'%Y%m%d').tgz"
 MAXMIND_LICENSE_KEY=$(aws ssm get-parameter \
                     --output text \
                     --name "/cyhy/core/geoip/license_key" \


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the ` generate_cyhy_docker_image.sh` helper script to:
1. Pull the MaxMind GeoIP2 license key from AWS SSM's Parameter Store.
1. Allow you to specify a custom image name without having to specify a tag.
1. Update the output file name to reflect the image name and tag being used.
1. Improve the way the script handles command line arguments, making it easier to add additional functionality in the future.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

After a team discussion I needed to change how the MaxMind license key was retrieved to reflect the way I was doing it in my local repository. Pulling directly from the Parameter Store using the AWS CLI is a better way to populate that value than how it was done previously. While I was updating the script I wanted to add the ability to specify a custom image name without needed to specify a custom tag. This necessitated rewriting the command line argument logic.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that the command line arguments work as expected.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more un-checked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] All relevant type-of-change labels have been added.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] All new and existing tests pass.
