### PR TITLE
Adding functionality to check for 'no-scan' countries

### DIFF
--- a/.bash_history
+++ b/.bash_history
@@ -1,0 +1,3 @@
+cd /usr/local/share/GeoIP/
+ls
+exit

--- a/.bash_history
+++ b/.bash_history
@@ -1,3 +1,0 @@
-cd /usr/local/share/GeoIP/
-ls
-exit

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -28,7 +28,7 @@ import dateutil
 from docopt import docopt
 from collections import defaultdict
 import progressbar as pb
-import netaddr
+from netaddr import IPSet
 
 # cisagov Libraries
 from cyhy.core import Config, STATUS, STAGE

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -33,6 +33,7 @@ import netaddr
 from cyhy.core import Config, STATUS, STAGE
 from cyhy.db import database
 from cyhy.util import util
+from cyhy.core.geoloc import GeoLocDB
 
 PB_INIT_WIDGETS = [
     "Importing: ",
@@ -79,6 +80,16 @@ def has_intersections(db, nets, filename, owner):
         print_intersections(intersections)
         return True
 
+def has_restricted_ips(nets):
+    geo_loc_db = GeoLocDB()
+    has_restricted = False
+    for cidr in nets.iter_cidrs():
+        if geo_loc_db.check_restricted_cidr(cidr):
+            has_restricted = True
+    if has_restricted:
+        return True
+    else:
+        return False
 
 def import_request(db, request, source, force=False, init_stage=None):
     owner = request["_id"]
@@ -92,6 +103,8 @@ def import_request(db, request, source, force=False, init_stage=None):
     if init_stage:
         request["init_stage"] = init_stage
     if has_intersections(db, nets, source, owner):
+        return False
+    if has_restricted_ips(nets):
         return False
     request["networks"] = nets.iter_cidrs()
 
@@ -146,6 +159,9 @@ def main():
 
     if not success:
         sys.exit(-1)
+    else:
+        print("Success.")
+
 
 
 if __name__ == "__main__":

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -32,9 +32,9 @@ import netaddr
 
 # cisagov Libraries
 from cyhy.core import Config, STATUS, STAGE
+from cyhy.core.geoloc import GeoLocDB
 from cyhy.db import database
 from cyhy.util import util
-from cyhy.core.geoloc import GeoLocDB
 
 PB_INIT_WIDGETS = [
     "Importing: ",

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -106,6 +106,9 @@ def import_request(db, request, source, force=False, init_stage=None):
     if has_intersections(db, nets, source, owner):
         return False
     if has_restricted_ips(nets):
+        #This is not combined with the previous check so the output
+        #from each function can be seen so the user can get all messages
+        # without multiple runs
         return False
     request["networks"] = nets.iter_cidrs()
 

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -33,6 +33,7 @@ import netaddr
 from cyhy.core import Config, STATUS, STAGE
 from cyhy.db import database
 from cyhy.util import util
+import geoip2.database
 
 PB_INIT_WIDGETS = [
     "Importing: ",
@@ -79,6 +80,21 @@ def has_intersections(db, nets, filename, owner):
         print_intersections(intersections)
         return True
 
+def has_restricted_ips(nets):
+    reader = geoip2.database.Reader('/usr/local/share/GeoIP/GeoIP2-City.mmdb')
+    bad_countries = ['China','Russia','Iran','North Korea']
+    has_bad_address = False
+
+    for cidr in nets.iter_cidrs():
+        geo_data = reader.city(str(cidr[0]))
+        country_name = geo_data.country.name
+        if country_name in bad_countries:
+            print('{} contains addresses in country that is unavailable due to current scanning policy: {}'.format(cidr,country_name))
+            has_bad_address = True
+    if has_bad_address:
+        return True
+    else:
+        return False
 
 def import_request(db, request, source, force=False, init_stage=None):
     owner = request["_id"]
@@ -93,6 +109,8 @@ def import_request(db, request, source, force=False, init_stage=None):
         request["init_stage"] = init_stage
     if has_intersections(db, nets, source, owner):
         return False
+    if has_restricted_ips(nets):
+        return False   
     request["networks"] = nets.iter_cidrs()
 
     for window in request["windows"]:

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -26,6 +26,7 @@ import sys
 # Third-Party Libraries
 import dateutil
 from docopt import docopt
+from collections import defaultdict
 import progressbar as pb
 import netaddr
 
@@ -82,17 +83,25 @@ def has_intersections(db, nets, filename, owner):
 
 def has_restricted_ips(nets):
     geo_loc_db = GeoLocDB()
-    has_restricted = False
-    for cidr in nets.iter_cidrs():
-        if geo_loc_db.check_restricted_cidr(cidr):
+    restricted_dict = defaultdict(lambda: netaddr.IPSet())
+    for ip in nets:
+        is_restricted, country = geo_loc_db.check_restricted_ip(ip)
+        if is_restricted:
+            restricted_dict[country].add(ip)
             # We can't just exit here since check_restricted_cidr()
             # prints output for each restricted CIDR block and we
             # want the user to see all restricted CIDR blocks
             # without having to run multiple times.
-            has_restricted = True
-    if has_restricted:
-        print "Cannot import.\nSome addresses traced to restricted countries."
-    return has_restricted
+    if len(restricted_dict) > 0:
+        print "***Found IPs in restricted countries***"
+        for country, cidrs in restricted_dict.items():
+            print "%s:" % country
+            for cidr in cidrs.iter_cidrs():
+                print "    %s" % cidr
+        print "Cannot continue!\nSome addresses associated with restricted countries."
+        return True
+    return False
+
 
 def import_request(db, request, source, force=False, init_stage=None):
     owner = request["_id"]

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -27,8 +27,8 @@ import sys
 # Third-Party Libraries
 import dateutil
 from docopt import docopt
-import progressbar as pb
 from netaddr import IPSet
+import progressbar as pb
 
 # cisagov Libraries
 from cyhy.core import Config, STATUS, STAGE

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -106,8 +106,8 @@ def import_request(db, request, source, force=False, init_stage=None):
     if has_intersections(db, nets, source, owner):
         return False
     if has_restricted_ips(nets):
-        #This is not combined with the previous check so the output
-        #from each function can be seen so the user can get all messages
+        # This is not combined with the previous check so the output
+        # from each function can be seen so the user can get all messages
         # without multiple runs
         return False
     request["networks"] = nets.iter_cidrs()

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -82,8 +82,8 @@ def has_intersections(db, nets, filename, owner):
 
 def has_restricted_ips(nets):
     reader = geoip2.database.Reader('/usr/local/share/GeoIP/GeoIP2-City.mmdb')
-    bad_countries = ['China','Russia','Iran','North Korea']
-    has_bad_address = False
+    restricted_countries = ['China','Russia','Iran','North Korea']
+    has_restricted_address = False
 
     for cidr in nets.iter_cidrs():
         geo_data = reader.city(str(cidr[0]))

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -85,11 +85,12 @@ def has_restricted_ips(nets):
     has_restricted = False
     for cidr in nets.iter_cidrs():
         if geo_loc_db.check_restricted_cidr(cidr):
+            # We can't just exit here since check_restricted_cidr()
+            # prints output for each restricted CIDR block and we
+            # want the user to see all restricted CIDR blocks
+            # without having to run multiple times.
             has_restricted = True
-    if has_restricted:
-        return True
-    else:
-        return False
+    return has_restricted
 
 def import_request(db, request, source, force=False, init_stage=None):
     owner = request["_id"]

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -90,6 +90,8 @@ def has_restricted_ips(nets):
             # want the user to see all restricted CIDR blocks
             # without having to run multiple times.
             has_restricted = True
+    if has_restricted:
+        print >> sys.stderr,"Cannot import.\nSome addresses traced to restricted countries."
     return has_restricted
 
 def import_request(db, request, source, force=False, init_stage=None):

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -92,7 +92,7 @@ def has_restricted_ips(nets):
             # prints output for each restricted CIDR block and we
             # want the user to see all restricted CIDR blocks
             # without having to run multiple times.
-    if len(restricted_dict) > 0:
+    if restricted_dict:
         print "***Found IPs in restricted countries***"
         for country, cidrs in restricted_dict.items():
             print "%s:" % country

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -81,6 +81,7 @@ def has_intersections(db, nets, filename, owner):
         print_intersections(intersections)
         return True
 
+
 def has_restricted_ips(nets):
     geo_loc_db = GeoLocDB()
     restricted_dict = defaultdict(lambda: IPSet())

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -90,11 +90,9 @@ def has_restricted_ips(nets):
         country_name = geo_data.country.name
         if country_name in bad_countries:
             print('{} contains addresses in country that is unavailable due to current scanning policy: {}'.format(cidr,country_name))
-            has_bad_address = True
-    if has_bad_address:
-        return True
-    else:
-        return False
+            has_restricted_address = True
+
+    return has_restricted_address
 
 def import_request(db, request, source, force=False, init_stage=None):
     owner = request["_id"]

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -163,9 +163,6 @@ def main():
 
     if not success:
         sys.exit(-1)
-    else:
-        print("Success.")
-
 
 
 if __name__ == "__main__":

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -91,7 +91,7 @@ def has_restricted_ips(nets):
             # without having to run multiple times.
             has_restricted = True
     if has_restricted:
-        print >> sys.stderr,"Cannot import.\nSome addresses traced to restricted countries."
+        print "Cannot import.\nSome addresses traced to restricted countries."
     return has_restricted
 
 def import_request(db, request, source, force=False, init_stage=None):

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -19,10 +19,10 @@ Notes:
 """
 
 # Standard Python Libraries
+from collections import defaultdict
 import datetime
 import json
 import sys
-from collections import defaultdict
 
 # Third-Party Libraries
 import dateutil

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -22,11 +22,11 @@ Notes:
 import datetime
 import json
 import sys
+from collections import defaultdict
 
 # Third-Party Libraries
 import dateutil
 from docopt import docopt
-from collections import defaultdict
 import progressbar as pb
 from netaddr import IPSet
 
@@ -85,8 +85,8 @@ def has_restricted_ips(nets):
     geo_loc_db = GeoLocDB()
     restricted_dict = defaultdict(lambda: netaddr.IPSet())
     for ip in nets:
-        is_restricted, country = geo_loc_db.check_restricted_ip(ip)
-        if is_restricted:
+        country = geo_loc_db.check_restricted_ip(ip)
+        if country:
             restricted_dict[country].add(ip)
             # We can't just exit here since check_restricted_cidr()
             # prints output for each restricted CIDR block and we

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -83,7 +83,7 @@ def has_intersections(db, nets, filename, owner):
 
 def has_restricted_ips(nets):
     geo_loc_db = GeoLocDB()
-    restricted_dict = defaultdict(lambda: netaddr.IPSet())
+    restricted_dict = defaultdict(lambda: IPSet())
     for ip in nets:
         country = geo_loc_db.check_restricted_ip(ip)
         if country:

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -31,7 +31,6 @@ from cyhy.core import Config, STATUS, STAGE
 from cyhy.db import database, CHDatabase
 from cyhy.util import util
 from cyhy.core.geoloc import GeoLocDB
-import geoip2.database
 from cyhy.core.common import *
 
 

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -166,7 +166,7 @@ def add(db, owner, cidrs):
     geo_loc_db = GeoLocDB()
     restricted_dict = defaultdict(lambda:IPSet())
     for ip in cidrs:
-        is_restricted,country = geo_loc_db.check_restricted_ip(ip)
+        is_restricted, country = geo_loc_db.check_restricted_ip(ip)
         if is_restricted:
             restricted_dict[country].add(ip)
             # We can't just exit here since check_restricted_cidr()

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -31,6 +31,7 @@ from cyhy.core import Config, STATUS, STAGE
 from cyhy.db import database, CHDatabase
 from cyhy.util import util
 from cyhy.core.geoloc import GeoLocDB
+import geoip2.database
 from cyhy.core.common import *
 
 
@@ -110,7 +111,22 @@ def get_special_intersections(cidrs):
             results[description] = intersection
     return results
 
+def has_restricted_ips(nets):
+    reader = geoip2.database.Reader('/usr/local/share/GeoIP/GeoIP2-City.mmdb')
+    bad_countries = ['China','Russia','Iran','North Korea']
+    has_bad_address = False
 
+    for cidr in nets.iter_cidrs():
+        geo_data = reader.city(str(cidr[0]))
+        country_name = geo_data.country.name
+        if country_name in bad_countries:
+            print('{} contains addresses in country that is unavailable due to current scanning policy: {}'.format(cidr,country_name))
+            has_bad_address = True
+    if has_bad_address:
+        return True
+    else:
+        return False
+  
 def print_intersections(intersections):
     for request, intersecting_cidrs in intersections.iteritems():
         if type(request) == str:
@@ -163,6 +179,8 @@ def add(db, owner, cidrs):
     intersections = db.RequestDoc.get_all_intersections(
         cidrs
     )  # intersections from database
+    if has_restricted_ips(cidrs):
+        print("Cannot continue!\nSome addresses are in invalid countries.") # Current countries that are not to be scanned.
     intersections.update(get_special_intersections(cidrs))  # intersections with RFCs
     if intersections:
         print "Cannot continue!\nSome addresses already allocated or reserved:"

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -164,7 +164,7 @@ def add(db, owner, cidrs):
         cidrs
     )  # intersections from database
     geo_loc_db = GeoLocDB()
-    restricted_dict = defaultdict(lambda:IPSet())
+    restricted_dict = defaultdict(lambda: IPSet())
     for ip in cidrs:
         is_restricted, country = geo_loc_db.check_restricted_ip(ip)
         if is_restricted:

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -174,7 +174,7 @@ def add(db, owner, cidrs):
             # want the user to see all restricted CIDR blocks
             # without having to run multiple times.
     if len(restricted_dict) > 0:
-        print("***Found IPs in restricted countries***")
+        print "***Found IPs in restricted countries***"
         for country, cidrs in restricted_dict.items():
             print "%s:" % country
             for cidr in cidrs.iter_cidrs():

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -166,8 +166,8 @@ def add(db, owner, cidrs):
     geo_loc_db = GeoLocDB()
     restricted_dict = defaultdict(lambda: IPSet())
     for ip in cidrs:
-        is_restricted, country = geo_loc_db.check_restricted_ip(ip)
-        if is_restricted:
+        country = geo_loc_db.check_restricted_ip(ip)
+        if country:
             restricted_dict[country].add(ip)
             # We can't just exit here since check_restricted_cidr()
             # prints output for each restricted CIDR block and we

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -179,7 +179,7 @@ def add(db, owner, cidrs):
             print "%s:" % country
             for cidr in cidrs.iter_cidrs():
                 print "    %s" % cidr
-        print "Cannot continue!\nSome addresses traced to restricted countries."
+        print "Cannot continue!\nSome addresses associated with restricted countries."
         sys.exit(-1)
 
     intersections.update(get_special_intersections(cidrs))  # intersections with RFCs

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -164,8 +164,7 @@ def add(db, owner, cidrs):
     )  # intersections from database
     geo_loc_db = GeoLocDB()
     for cidr in cidrs.iter_cidrs():
-        has_restricted = geo_loc_db.check_restricted_cidr(cidr)
-        if has_restricted:
+        if geo_loc_db.check_restricted_cidr(cidr):
             print("Cannot continue!\nSome addresses are in restricted countries.")
             sys.exit(-1)
 

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -6,7 +6,7 @@ Usage:
   cyhy-ip [--section SECTION] [--file FILENAME] (check | normalize) [ADDRESSES ...]
   cyhy-ip [--section SECTION] [--file FILENAME] setstage STAGE [ADDRESSES ...]
   cyhy-ip [--section SECTION] list OWNER
-  cyhy-ip [--section SECTION] list-all 
+  cyhy-ip [--section SECTION] list-all
   cyhy-ip [--section SECTION] [--file FILENAME] move OWNER NEW_OWNER [ADDRESSES ...]
   cyhy-ip (-h | --help)
   cyhy-ip --version
@@ -14,10 +14,10 @@ Usage:
 Options:
   -h --help                      Show this screen.
   --version                      Show version.
-  
+
   -f FILENAME --file=FILENAME    Read addresses from a file.
   -s SECTION --section=SECTION   Configuration section to use.
-  
+
 Notes:
   Address can be read from standard input if no addresses are provided on the command line
   and the --file option is omitted.
@@ -36,11 +36,11 @@ from cyhy.core.common import *
 
 def munge(x):
     """Munges a tuple or list of IPNetwork and IPRange objects into a single IPSet.
-    
+
     Args:
         x: A Python tuple or list containing IPNetwork and IPRange objects
-        
-    Returns: 
+
+    Returns:
         An IPSet corresponding to the Python tuple or list that was passed
         in.
     """
@@ -110,7 +110,6 @@ def get_special_intersections(cidrs):
             results[description] = intersection
     return results
 
-
 def print_intersections(intersections):
     for request, intersecting_cidrs in intersections.iteritems():
         if type(request) == str:
@@ -163,6 +162,13 @@ def add(db, owner, cidrs):
     intersections = db.RequestDoc.get_all_intersections(
         cidrs
     )  # intersections from database
+    geo_loc_db = GeoLocDB()
+    for cidr in cidrs.iter_cidrs():
+        has_restricted = geo_loc_db.check_restricted_cidr(cidr)
+        if has_restricted:
+            print("Cannot continue!\nSome addresses are in restricted countries.")
+            sys.exit(-1)
+
     intersections.update(get_special_intersections(cidrs))  # intersections with RFCs
     if intersections:
         print "Cannot continue!\nSome addresses already allocated or reserved:"
@@ -172,7 +178,7 @@ def add(db, owner, cidrs):
     # init new hosts documents
     # get the init_stage, if it doesn't have one assume NETSCAN1
     stage = STAGE[request.get("init_stage", STAGE.NETSCAN1)]
-    geo_loc_db = GeoLocDB()
+
     pbar = pb.ProgressBar(widgets=PB_INIT_WIDGETS, maxval=len(cidrs)).start()
     pbar.widgets[0] = "Adding %s: " % owner
     i = 0
@@ -183,7 +189,7 @@ def add(db, owner, cidrs):
         host.save()
         i += 1
         pbar.update(i)
-    # update request with new networks
+    update request with new networks
     request.add_networks(cidrs)
     request.save()
     print "IPs added to request, and initialized.  Tally sync required to start scan of new IPs."

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -25,8 +25,8 @@ Notes:
 
 from collections import defaultdict
 import sys
-import progressbar as pb
 from docopt import docopt
+import progressbar as pb
 from netaddr import ip, IPNetwork, IPRange, IPSet
 from cyhy.core import Config, STATUS, STAGE
 from cyhy.db import database, CHDatabase

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -189,7 +189,7 @@ def add(db, owner, cidrs):
         host.save()
         i += 1
         pbar.update(i)
-    update request with new networks
+    # update request with new networks
     request.add_networks(cidrs)
     request.save()
     print "IPs added to request, and initialized.  Tally sync required to start scan of new IPs."

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -23,10 +23,10 @@ Notes:
   and the --file option is omitted.
 """
 
+from collections import defaultdict
 import sys
 import progressbar as pb
 from docopt import docopt
-from collections import defaultdict
 from netaddr import ip, IPNetwork, IPRange, IPSet
 from cyhy.core import Config, STATUS, STAGE
 from cyhy.db import database, CHDatabase

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -175,10 +175,10 @@ def add(db, owner, cidrs):
             # without having to run multiple times.
     if len(restricted_dict) > 0:
         print("***Found IPs in restricted countries***")
-        for key,value in restricted_dict.items():
-            print("%s:" % key)
-            for cidr in value.iter_cidrs():
-                print("    %s" % cidr)
+        for country, cidrs in restricted_dict.items():
+            print "%s:" % country
+            for cidr in cidrs.iter_cidrs():
+                print "    %s" % cidr
         print "Cannot continue!\nSome addresses traced to restricted countries."
         sys.exit(-1)
 

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -168,7 +168,7 @@ def add(db, owner, cidrs):
         if geo_loc_db.check_restricted_cidr(cidr):
             has_restricted_ips = True
     if has_restricted_ips:
-        print >> sys.stderr,"Cannot continue!\nSome addresses traced to restricted countries."
+        print "Cannot continue!\nSome addresses traced to restricted countries."
         sys.exit(-1)
 
     intersections.update(get_special_intersections(cidrs))  # intersections with RFCs

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -163,10 +163,13 @@ def add(db, owner, cidrs):
         cidrs
     )  # intersections from database
     geo_loc_db = GeoLocDB()
+    has_restricted_ips = False
     for cidr in cidrs.iter_cidrs():
         if geo_loc_db.check_restricted_cidr(cidr):
-            print("Cannot continue!\nSome addresses are in restricted countries.")
-            sys.exit(-1)
+            has_restricted_ips = True
+    if has_restricted_ips:
+        print("Cannot continue!\n Some addresses traced to restricted counties.")
+        sys.exit(-1)
 
     intersections.update(get_special_intersections(cidrs))  # intersections with RFCs
     if intersections:

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -23,16 +23,22 @@ Notes:
   and the --file option is omitted.
 """
 
+# Standard Python Libraries
 from collections import defaultdict
 import sys
+
+# Third-Party Libraries
 from docopt import docopt
-import progressbar as pb
 from netaddr import ip, IPNetwork, IPRange, IPSet
+import progressbar as pb
+
+# cisagov Libraries
 from cyhy.core import Config, STATUS, STAGE
+from cyhy.core.common import *
+from cyhy.core.geoloc import GeoLocDB
 from cyhy.db import database, CHDatabase
 from cyhy.util import util
-from cyhy.core.geoloc import GeoLocDB
-from cyhy.core.common import *
+
 
 
 def munge(x):

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -26,6 +26,7 @@ Notes:
 import sys
 import progressbar as pb
 from docopt import docopt
+from collections import defaultdict
 from netaddr import ip, IPNetwork, IPRange, IPSet
 from cyhy.core import Config, STATUS, STAGE
 from cyhy.db import database, CHDatabase
@@ -163,15 +164,21 @@ def add(db, owner, cidrs):
         cidrs
     )  # intersections from database
     geo_loc_db = GeoLocDB()
-    has_restricted_ips = False
-    for cidr in cidrs.iter_cidrs():
-        if geo_loc_db.check_restricted_cidr(cidr):
+    restricted_dict = defaultdict(lambda:IPSet())
+    for ip in cidrs:
+        is_restricted,country = geo_loc_db.check_restricted_ip(ip)
+        if is_restricted:
+            restricted_dict[country].add(ip)
             # We can't just exit here since check_restricted_cidr()
             # prints output for each restricted CIDR block and we
             # want the user to see all restricted CIDR blocks
             # without having to run multiple times.
-            has_restricted_ips = True
-    if has_restricted_ips:
+    if len(restricted_dict) > 0:
+        print("***Found IPs in restricted countries***")
+        for key,value in restricted_dict.items():
+            print("%s:" % key)
+            for cidr in value.iter_cidrs():
+                print("    %s" % cidr)
         print "Cannot continue!\nSome addresses traced to restricted countries."
         sys.exit(-1)
 

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -173,7 +173,7 @@ def add(db, owner, cidrs):
             # prints output for each restricted CIDR block and we
             # want the user to see all restricted CIDR blocks
             # without having to run multiple times.
-    if len(restricted_dict) > 0:
+    if restricted_dict:
         print "***Found IPs in restricted countries***"
         for country, cidrs in restricted_dict.items():
             print "%s:" % country

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -180,7 +180,6 @@ def add(db, owner, cidrs):
     # init new hosts documents
     # get the init_stage, if it doesn't have one assume NETSCAN1
     stage = STAGE[request.get("init_stage", STAGE.NETSCAN1)]
-
     pbar = pb.ProgressBar(widgets=PB_INIT_WIDGETS, maxval=len(cidrs)).start()
     pbar.widgets[0] = "Adding %s: " % owner
     i = 0

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -168,7 +168,7 @@ def add(db, owner, cidrs):
         if geo_loc_db.check_restricted_cidr(cidr):
             has_restricted_ips = True
     if has_restricted_ips:
-        print("Cannot continue!\n Some addresses traced to restricted counties.")
+        print >> sys.stderr,"Cannot continue!\nSome addresses traced to restricted countries."
         sys.exit(-1)
 
     intersections.update(get_special_intersections(cidrs))  # intersections with RFCs

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -166,6 +166,10 @@ def add(db, owner, cidrs):
     has_restricted_ips = False
     for cidr in cidrs.iter_cidrs():
         if geo_loc_db.check_restricted_cidr(cidr):
+            # We can't just exit here since check_restricted_cidr()
+            # prints output for each restricted CIDR block and we
+            # want the user to see all restricted CIDR blocks
+            # without having to run multiple times.
             has_restricted_ips = True
     if has_restricted_ips:
         print "Cannot continue!\nSome addresses traced to restricted countries."

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -45,7 +45,7 @@ class GeoLocDB(object):
         try:
             response = self.__reader.city(str(ip))
             if response.country.name in RESTRICTED_COUNTRIES:
-                return True
-            return False
+                return True,response.country.name
+            return False,None
         except AddressNotFoundError:
             print >> sys.stderr, "CIDR %s not found in geolocation database" % cidr

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -12,7 +12,7 @@ from geoip2.errors import AddressNotFoundError
 GEODB_FILES = ["GeoIP2-City.mmdb", "GeoLite2-City.mmdb"]
 GEODB_CITY_PATHS = ["/usr/share/GeoIP/", "/usr/local/share/GeoIP/"]
 GEODB_FILE_PATHS = []
-RESTRICTED_COUNTRIES = ["China","Iran","North Korea","Russia"]
+RESTRICTED_COUNTRIES = ["China", "Iran", "North Korea", "Russia"]
 # Ensure that the order in GEODB_FILES is used for searching
 for file in GEODB_FILES:
     for path in GEODB_CITY_PATHS:

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -46,8 +46,8 @@ class GeoLocDB(object):
         try:
             response = self.__reader.city(str(cidr[0]))
             if response.country.name in RESTRICTED_COUNTRIES:
-                print("Warning! %s traced to restricted country: %s" % (cidr, response.country.name))
+                print >> sys.stderr, "Warning! %s traced to restricted country: %s" % (cidr, response.country.name)
                 has_restricted = True
         except AddressNotFoundError:
-            sys.stderr.write("CIDR %s not found in geolocation database\n" % cidr)
+            print >> sys.stderr, "CIDR %s not found in geolocation database" % cidr
         return has_restricted

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -55,7 +55,7 @@ class GeoLocDB(object):
         # this is only printing the cidr in which one or more addresses are found
         # that correspond to a restricted country
         if len(restricted_ips) > 0:
-            print >> sys.stderr, "Warning! The follwing networks can be traced to restricted country: %s" % response.country.name
+            print >> sys.stderr, "Warning! The following networks can be traced to restricted country: %s" % response.country.name
             for network in restricted_ips.iter_cidrs():
                 print >> sys.stderr, network
             return True

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -45,7 +45,6 @@ class GeoLocDB(object):
         try:
             response = self.__reader.city(str(ip))
             if response.country.name in RESTRICTED_COUNTRIES:
-                return True,response.country.name
-            return False,None
+                return True, response.country.name
         except AddressNotFoundError:
             print >> sys.stderr, "CIDR %s not found in geolocation database" % cidr

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -39,3 +39,15 @@ class GeoLocDB(object):
             return (response.location.longitude, response.location.latitude)
         except AddressNotFoundError:
             return (None, None)
+
+    def check_restricted_cidr(self, cidr):
+        restricted_countries = ["China","Iran","North Korea","Russia"]
+        has_restricted = False
+        try:
+            response = self.__reader.city(str(cidr[0]))
+            if response.country.name in restricted_countries:
+                print("Warning! %s traced to restricted country: %s" % (cidr, response.country.name))
+                has_restricted = True
+        except AddressNotFoundError:
+            print('Address not found.')
+        return has_restricted

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -49,5 +49,5 @@ class GeoLocDB(object):
                 print("Warning! %s traced to restricted country: %s" % (cidr, response.country.name))
                 has_restricted = True
         except AddressNotFoundError:
-            print("CIDR %s not found in geolocation database" % cidr)
+            sys.stderr.write("CIDR %s not found in geolocation database\n" % cidr)
         return has_restricted

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -49,5 +49,5 @@ class GeoLocDB(object):
                 print("Warning! %s traced to restricted country: %s" % (cidr, response.country.name))
                 has_restricted = True
         except AddressNotFoundError:
-            print('Address not found.')
+            print("CIDR %s not found in geolocation database", cidr)
         return has_restricted

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -43,11 +43,16 @@ class GeoLocDB(object):
 
     def check_restricted_cidr(self, cidr):
         has_restricted = False
-        try:
-            response = self.__reader.city(str(cidr[0]))
-            if response.country.name in RESTRICTED_COUNTRIES:
-                print >> sys.stderr, "Warning! %s traced to restricted country: %s" % (cidr, response.country.name)
-                has_restricted = True
-        except AddressNotFoundError:
-            print >> sys.stderr, "CIDR %s not found in geolocation database" % cidr
+        for ip in cidr:
+            try:
+                response = self.__reader.city(str(ip))
+                if response.country.name in RESTRICTED_COUNTRIES:
+                    has_restricted = True
+            except AddressNotFoundError:
+                print >> sys.stderr, "CIDR %s not found in geolocation database" % cidr
+        # to avoid printing each and every ip in a cidr that is found
+        # this is only printing the cidr in which one or more addresses are found
+        # that correspond to a restricted country 
+        if has_restricted:
+            print >> sys.stderr, "Warning! %s traced to restricted country: %s" % (cidr, response.country.name)
         return has_restricted

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -41,18 +41,11 @@ class GeoLocDB(object):
         except AddressNotFoundError:
             return (None, None)
 
-    def check_restricted_cidr(self, cidr):
-        restricted_ips = IPSet()
-        for ip in cidr:
-            try:
-                response = self.__reader.city(str(ip))
-                if response.country.name in RESTRICTED_COUNTRIES:
-                    restricted_ips.add(ip)
-            except AddressNotFoundError:
-                print >> sys.stderr, "CIDR %s not found in geolocation database" % cidr
-        if len(restricted_ips) > 0:
-            print >> sys.stderr, "Warning! The following networks can be traced to restricted country: %s" % response.country.name
-            for network in restricted_ips.iter_cidrs():
-                print >> sys.stderr, network
-            return True
-        return False
+    def check_restricted_ip(self, ip):
+        try:
+            response = self.__reader.city(str(ip))
+            if response.country.name in RESTRICTED_COUNTRIES:
+                return True
+            return False
+        except AddressNotFoundError:
+            print >> sys.stderr, "CIDR %s not found in geolocation database" % cidr

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -49,5 +49,5 @@ class GeoLocDB(object):
                 print("Warning! %s traced to restricted country: %s" % (cidr, response.country.name))
                 has_restricted = True
         except AddressNotFoundError:
-            print("CIDR %s not found in geolocation database", cidr)
+            print("CIDR %s not found in geolocation database" % cidr)
         return has_restricted

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -4,7 +4,6 @@ __all__ = ["GeoLocDB"]
 
 import os
 import sys
-from netaddr import IPSet
 
 import geoip2.database
 from geoip2.errors import AddressNotFoundError

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -11,6 +11,7 @@ from geoip2.errors import AddressNotFoundError
 GEODB_FILES = ["GeoIP2-City.mmdb", "GeoLite2-City.mmdb"]
 GEODB_CITY_PATHS = ["/usr/share/GeoIP/", "/usr/local/share/GeoIP/"]
 GEODB_FILE_PATHS = []
+RESTRICTED_COUNTRIES = ["China","Iran","North Korea","Russia"]
 # Ensure that the order in GEODB_FILES is used for searching
 for file in GEODB_FILES:
     for path in GEODB_CITY_PATHS:
@@ -41,11 +42,10 @@ class GeoLocDB(object):
             return (None, None)
 
     def check_restricted_cidr(self, cidr):
-        restricted_countries = ["China","Iran","North Korea","Russia"]
         has_restricted = False
         try:
             response = self.__reader.city(str(cidr[0]))
-            if response.country.name in restricted_countries:
+            if response.country.name in RESTRICTED_COUNTRIES:
                 print("Warning! %s traced to restricted country: %s" % (cidr, response.country.name))
                 has_restricted = True
         except AddressNotFoundError:

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -45,8 +45,8 @@ class GeoLocDB(object):
         try:
             response = self.__reader.city(str(ip))
             if response.country.name in RESTRICTED_COUNTRIES:
-                return True, response.country.name
+                return response.country.name
         except AddressNotFoundError:
             print >> sys.stderr, "CIDR %s not found in geolocation database" % cidr
 
-        return False, ""
+        return ""

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -51,9 +51,6 @@ class GeoLocDB(object):
                     restricted_ips.add(ip)
             except AddressNotFoundError:
                 print >> sys.stderr, "CIDR %s not found in geolocation database" % cidr
-        # to avoid printing each and every ip in a cidr that is found
-        # this is only printing the cidr in which one or more addresses are found
-        # that correspond to a restricted country
         if len(restricted_ips) > 0:
             print >> sys.stderr, "Warning! The following networks can be traced to restricted country: %s" % response.country.name
             for network in restricted_ips.iter_cidrs():

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -48,3 +48,5 @@ class GeoLocDB(object):
                 return True, response.country.name
         except AddressNotFoundError:
             print >> sys.stderr, "CIDR %s not found in geolocation database" % cidr
+
+        return False, ""


### PR DESCRIPTION
## 🗣 Description ##

This is a change designed to check the GeoIP db for IPs in countries that are currently not supposed to be scanned per policy. 

## 💭 Motivation and context ##

This change is required because we recently officially updated our scanning policy across VM to exclude scans to IPs located in certain countries. This change solves the problem by adding an automatic check to look up the country for each CIDR that is either imported or added to avoid importing IPs that should not be scanned.

## 🧪 Testing ##

I tested this change by forking my own repo and then generating a local docker instance, with the actual importing steps that would change the DB commented out. I then made a dummy json file and attempted to import it with known IPs that belong to those countries. I also tested the 'add' functionality in the same way, commenting out the actual addition, but attempting to add known IPs that belong to said countries. The tests were successful as I tried them.
