### PR TITLE
Add KEV importer

### DIFF
--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+"""Parse KEV (Known Exploited Vulnerabilities) JSON file and save to database.
+
+Usage:
+  cyhy-kevsync [--section SECTION]
+  cyhy-kevsync [--section SECTION] --local-file <json-file>
+  cyhy-kevsync (-h | --help)
+  cyhy-kevsync --version
+
+Options:
+  -h --help                      Show this screen.
+  -f --local-file                Import KEV data from a local file.
+  --version                      Show version.
+  -s SECTION --section=SECTION   Configuration section to use.
+
+"""
+
+# standard python libraries
+import json
+import urllib
+from StringIO import StringIO
+
+# third-party libraries (install with pip)
+from docopt import docopt
+
+# intra-project modules
+from cyhy.db import database
+from cyhy.util import util
+
+KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+
+
+def remove_outdated(db, imported_cves):
+    # Find KEV CVEs in DB that were NOT imported just now
+    outdated_kevs = db.KEVDoc.find({"_id": {"$nin": imported_cves}})
+    outdated_cves = [i["_id"] for i in outdated_kevs]
+
+    if outdated_cves:
+        # Remove outdated CVEs from KEV collection
+        db.KEVDoc.collection.remove({"_id": {"$in": outdated_cves}})
+
+        print("The following CVEs were removed from the KEV collection:")
+        print("\n".join(outdated_cves))
+
+
+def parse_json(db, json_stream):
+    data = json.load(json_stream)
+
+    # Gather all the cveIDs from the JSON file
+    all_cve_ids = set()
+    for i in data.get("vulnerabilities"):
+        cveID = i.get("cveID")
+        if not cveID:
+            raise ValueError("JSON does not look like valid CISA KEV data.")
+        else:
+            all_cve_ids.add(cveID)
+
+    # Insert a KEV document for each CVE
+    for cve in all_cve_ids:
+        entry_doc = db.KEVDoc({"_id": cve})
+        entry_doc.save(safe=False)
+
+    print("Imported %d KEV entries." % len(all_cve_ids))
+    if data.get("count") != len(all_cve_ids):
+        print(
+            "WARNING: KEV JSON file 'count' (%d) differs from number of records in file (%d)."
+            % (data.get("count"), len(all_cve_ids))
+        )
+
+    return list(all_cve_ids)
+
+
+def process_file(db, filename):
+    stream = open(filename, "r")
+    return parse_json(db, stream)
+
+
+def process_url(db, url):
+    socket = urllib.urlopen(url)
+    buf = StringIO(socket.read())
+    return parse_json(db, buf)
+
+
+def main():
+    args = docopt(__doc__, version="v0.0.1")
+
+    db = database.db_from_config(args["--section"])
+
+    if args["--local-file"]:
+        imported_cves = process_file(db, args["<json-file>"])
+    else:
+        imported_cves = process_url(db, KEV_URL)
+
+    if imported_cves:
+        remove_outdated(db, imported_cves)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -50,11 +50,11 @@ def parse_json(db, json_stream):
     # Gather all the cveIDs from the JSON file
     all_cve_ids = set()
     for i in data.get("vulnerabilities"):
-        cveID = i.get("cveID")
-        if not cveID:
+        cve_id = i.get("cveID")
+        if not cve_id:
             raise ValueError("JSON does not look like valid CISA KEV data.")
         else:
-            all_cve_ids.add(cveID)
+            all_cve_ids.add(cve_id)
 
     # Insert a KEV document for each CVE
     for cve in all_cve_ids:

--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -3,8 +3,7 @@
 """Parse KEV (Known Exploited Vulnerabilities) JSON file and save to database.
 
 Usage:
-  cyhy-kevsync [--section SECTION]
-  cyhy-kevsync [--section SECTION] --local-file <json-file>
+  cyhy-kevsync [--section SECTION] [--local-file <json-file>]
   cyhy-kevsync (-h | --help)
   cyhy-kevsync --version
 

--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -46,6 +46,7 @@ def remove_outdated(db, imported_cves):
 
 def parse_json(db, json_stream):
     data = json.load(json_stream)
+    json_stream.close()
 
     # Gather all the cveIDs from the JSON file
     all_cve_ids = set()

--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -62,11 +62,14 @@ def parse_json(db, json_stream):
         entry_doc.save(safe=False)
 
     print("Imported %d KEV entries." % len(all_cve_ids))
-    if data.get("count") != len(all_cve_ids):
-        print(
-            "WARNING: KEV JSON file 'count' (%d) differs from number of records in file (%d)."
-            % (data.get("count"), len(all_cve_ids))
-        )
+    if data.get("count"):
+        if data["count"] != len(all_cve_ids):
+            print(
+                "WARNING: KEV JSON file 'count' (%d) differs from number of records in file (%d)."
+                % (data.get("count"), len(all_cve_ids))
+            )
+    else:
+        print("WARNING: KEV JSON file is missing 'count' field.")
 
     return list(all_cve_ids)
 

--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -49,7 +49,7 @@ def parse_json(db, json_stream):
 
     # Gather all the cveIDs from the JSON file
     all_cve_ids = set()
-    for i in data.get("vulnerabilities"):
+    for i in data["vulnerabilities"]:
         cve_id = i.get("cveID")
         if not cve_id:
             raise ValueError("JSON does not look like valid CISA KEV data.")

--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -18,8 +18,8 @@ Options:
 
 # standard python libraries
 import json
-import urllib
 from StringIO import StringIO
+import urllib
 
 # third-party libraries (install with pip)
 from docopt import docopt

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -18,21 +18,22 @@ from cyhy.core.config import Config
 from cyhy.core.yaml_config import YamlConfig
 from cyhy.util import util
 
-REQUEST_COLLECTION = "requests"
-HOST_COLLECTION = "hosts"
-TALLY_COLLECTION = "tallies"
-SNAPSHOT_COLLECTION = "snapshots"
-HOST_SCAN_COLLECTION = "host_scans"
-PORT_SCAN_COLLECTION = "port_scans"
-VULN_SCAN_COLLECTION = "vuln_scans"
-TICKET_COLLECTION = "tickets"
-SCORECARD_COLLECTION = "scorecards"
 CVE_COLLECTION = "cves"
-REPORT_COLLECTION = "reports"
-SYSTEM_CONTROL_COLLECTION = "control"
-PLACE_COLLECTION = "places"
+HOST_COLLECTION = "hosts"
+HOST_SCAN_COLLECTION = "host_scans"
 NEW_HIRE_COLLECTION = "new_hire"
 NOTIFICATION_COLLECTION = "notifications"
+PLACE_COLLECTION = "places"
+PORT_SCAN_COLLECTION = "port_scans"
+REPORT_COLLECTION = "reports"
+REQUEST_COLLECTION = "requests"
+SCORECARD_COLLECTION = "scorecards"
+SNAPSHOT_COLLECTION = "snapshots"
+SYSTEM_CONTROL_COLLECTION = "control"
+TALLY_COLLECTION = "tallies"
+TICKET_COLLECTION = "tickets"
+VULN_SCAN_COLLECTION = "vuln_scans"
+
 CONTROL_DOC_POLL_INTERVAL = 5  # seconds
 
 

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -21,6 +21,7 @@ from cyhy.util import util
 CVE_COLLECTION = "cves"
 HOST_COLLECTION = "hosts"
 HOST_SCAN_COLLECTION = "host_scans"
+KEV_COLLECTION = "kevs"
 NEW_HIRE_COLLECTION = "new_hire"
 NOTIFICATION_COLLECTION = "notifications"
 PLACE_COLLECTION = "places"
@@ -41,21 +42,22 @@ def db_from_connection(uri, name):
     con = MongoClient(host=uri, tz_aware=True)
     con.register(
         [
-            RequestDoc,
-            SnapshotDoc,
-            HostDoc,
-            TallyDoc,
-            HostScanDoc,
-            PortScanDoc,
-            VulnScanDoc,
-            TicketDoc,
-            ScorecardDoc,
             CVEDoc,
-            ReportDoc,
-            SystemControlDoc,
-            PlaceDoc,
             HireDoc,
+            HostDoc,
+            HostScanDoc,
+            KEVDoc,
             NotificationDoc,
+            PlaceDoc,
+            PortScanDoc,
+            ReportDoc,
+            RequestDoc,
+            ScorecardDoc,
+            SnapshotDoc,
+            SystemControlDoc,
+            TallyDoc,
+            TicketDoc,
+            VulnScanDoc,
         ]
     )
     db = con[name]
@@ -1681,6 +1683,16 @@ class NotificationDoc(RootDoc):
     }
     required_fields = ["ticket_id", "ticket_owner"]
     default_values = {"generated_for": []}
+
+    def get_indices(self):
+        return tuple()
+
+
+class KEVDoc(RootDoc):
+    __collection__ = KEV_COLLECTION
+    structure = {"_id": basestring}
+    required_fields = ["_id"]
+    default_values = {}
 
     def get_indices(self):
         return tuple()

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "bin/cyhy-geoip",
         "bin/cyhy-import",
         "bin/cyhy-ip",
+        "bin/cyhy-kevsync",
         "bin/cyhy-mongo",
         "bin/cyhy-nvdsync",
         "bin/cyhy-sched",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR defines a new collection to store KEV (Known Exploited Vulnerability) data and adds a new `cyhy-kevsync` utility that can import a JSON file containing the KEV data into the CyHy database.

Since I was here, I alphabetized our collection names in a couple of places.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Resolves https://github.com/cisagov/cyhy-system/issues/39 and resolves https://github.com/cisagov/cyhy-system/issues/40.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that `cyhy-kevsync` works as expected when run in the default mode (fetch JSON file from a well-known URL) and in the mode where a local JSON file is provided.

I also confirmed that previously-imported KEVs were correctly deleted from the database if they were not included in a more-recent JSON file that was imported.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR. (will be handled via https://github.com/cisagov/ncats-data-dictionary/issues/26)
- [x] All new and existing tests pass.
