### PR TITLE
Make the scheduler aware of KEVs

### DIFF
--- a/cyhy/db/queries.py
+++ b/cyhy/db/queries.py
@@ -269,6 +269,18 @@ def max_severity_for_host(ip_int):
     )
 
 
+def kev_count_for_host(ip_int):
+    """Return the number of open tickets that have kev set to true in its details."""
+    return (
+        [
+            {"$match": {"ip_int": ip_int, "open": True, "source": "nessus"}},
+            {"$match": {"details.kev": True}},
+            {"$group": {"_id": {}, "kev_count": {"$sum": 1}}},
+        ],
+        database.TICKET_COLLECTION,
+    )
+
+
 def false_positives_pl(snapshot_oid):
     return (
         [

--- a/cyhy/db/queries.py
+++ b/cyhy/db/queries.py
@@ -270,7 +270,7 @@ def max_severity_for_host(ip_int):
 
 
 def kev_count_for_host(ip_int):
-    """Return the number of open tickets that have kev set to true in its details."""
+    """Return the number of open tickets that have kev set to true in their details."""
     return (
         [
             {"$match": {"ip_int": ip_int, "open": True, "source": "nessus"}},

--- a/cyhy/db/scheduler.py
+++ b/cyhy/db/scheduler.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from datetime import datetime
 
 from cyhy.core.common import *
-from cyhy.db.queries import max_severity_for_host, kev_count_for_host
+from cyhy.db.queries import kev_count_for_host, max_severity_for_host
 from cyhy.db import database
 from cyhy.util import util
 

--- a/cyhy/db/scheduler.py
+++ b/cyhy/db/scheduler.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from datetime import datetime
 
 from cyhy.core.common import *
-from cyhy.db.queries import max_severity_for_host
+from cyhy.db.queries import max_severity_for_host, kev_count_for_host
 from cyhy.db import database
 from cyhy.util import util
 
@@ -37,7 +37,10 @@ class DefaultScheduler(BaseScheduler):
     # mapping of vuln severities to priorities
     SEVERITY_PRIORITY = {1: -2, 2: -4, 3: -8, 4: -16}
 
-    # create a series with all our priorites as the index
+    # KEVs are assigned the same priority as critical vulns
+    KEV_PRIORITY = SEVERITY_PRIORITY[4]
+
+    # create a series with all our priorities as the index
     PRIORITY_TIMES = pd.Series(np.nan, index=range(1, -17, -1))
 
     # set the time in hours for specific priorities
@@ -72,7 +75,13 @@ class DefaultScheduler(BaseScheduler):
         if host["priority"] < self.RESTING_DOWN_PRIORITY:
             host["priority"] += 1
 
-    def __process_vuln_host(self, host, max_severity):
+    def __process_vuln_host(self, host, max_severity, kev_count):
+        """Determine the priority of a host that has vulnerabilities."""
+        # If the host has any KEVs, then it is set to the KEV priority
+        if kev_count > 0:
+            host["priority"] = self.KEV_PRIORITY
+            return
+
         priority_from_severity = self.__priority_for_severity(max_severity)
 
         if priority_from_severity == host["priority"]:
@@ -88,6 +97,7 @@ class DefaultScheduler(BaseScheduler):
         host["priority"] += 1
 
     def __process_vuln_free_host(self, host):
+        """Determine the priority of a host that does not have vulnerabilities."""
         if host["priority"] < self.RESTING_UP_PRIORITY:
             # decay host back to "resting up"
             host["priority"] += 1
@@ -107,6 +117,19 @@ class DefaultScheduler(BaseScheduler):
             # no tickets
             return 0
 
+    def __host_kev_count(self, host):
+        """Get the number of KEVs for a host."""
+        ip_int = host["_id"]
+        q = kev_count_for_host(ip_int)
+        r = database.run_pipeline_cursor(q, self._db)
+        database.id_expand(r)
+        if len(r) > 0:
+            # found tickets
+            return r[0]["kev_count"]
+        else:
+            # no tickets
+            return 0
+
     def schedule(self, host):
         super(DefaultScheduler, self).schedule(host)
 
@@ -116,8 +139,9 @@ class DefaultScheduler(BaseScheduler):
         else:
             # host was up
             max_severity = self.__host_max_severity(host)
+            kev_count = self.__host_kev_count(host)
             if max_severity > 0:
-                self.__process_vuln_host(host, max_severity)
+                self.__process_vuln_host(host, max_severity, kev_count)
             else:
                 self.__process_vuln_free_host(host)
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR makes the scheduler aware of the KEV field in tickets.
As per the requirements, when a host has a ticket with `details.kev` set to `true` the scheduler will schedule this with the same priority as a critical vulnerability.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

These changes makes no sense.  I have no idea why we are doing it.  See: cisagov/cyhy-system#38
All vulnerabilities that end up in the "Known Exploited" catalog will already have high priorities from their CVSS scores.

Closing language:
- Placates and closes cisagov/cyhy-system#38
- Closes cisagov/cyhy-system#44
- Closes cisagov/cyhy-system#45  

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

- [x] Tested by scanning a host with a vulnerability that is listed in the KEV but no other concurrent criticals on the same host.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
