### PR TITLE
Create notifications for existing tickets

### DIFF
--- a/cyhy/db/ticket_manager.py
+++ b/cyhy/db/ticket_manager.py
@@ -88,9 +88,10 @@ class VulnTicketManager(object):
                 ticket["events"].append(event)
 
     def __generate_ticket_details(self, vuln, ticket, check_for_changes=True):
-        """generates the contents of the ticket's details field using NVD data.
+        """Generates the contents of the ticket's details field using NVD data.
         if check_for_changes is True, it will detect changes in the details,
-        and generate a CHANGED event."""
+        and generate a CHANGED event.  If a delta is generated, it will be
+        returned.  If no delta is generated, an empty list is returned."""
         new_details = {
             "cve": vuln.get("cve"),
             "score_source": vuln["source"],
@@ -106,6 +107,7 @@ class VulnTicketManager(object):
                 new_details["cvss_base_score"] = cve_doc["cvss_score"]
                 new_details["severity"] = cve_doc["severity"]
 
+        delta = []
         if check_for_changes:
             delta = self.__calculate_delta(ticket["details"], new_details)
             if delta:
@@ -121,6 +123,7 @@ class VulnTicketManager(object):
                 ticket["events"].append(event)
 
         ticket["details"] = new_details
+        return delta
 
     def __create_notification(self, ticket):
         """Create a notification from a ticket and save it in the database."""


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR causes notifications to be generated for existing tickets in certain specific situations, namely if an open (non-false positive) ticket or a re-opened ticket does one of the following:
- Its severity changes from less than 3 (High) to 3 or greater
- Its KEV flag changes from False to True

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
This is a requirement specified in https://github.com/cisagov/cyhy-system/issues/29.

Closing language:
- Closes https://github.com/cisagov/cyhy-system/issues/42

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

- [x] Verified that a notification was generated for an existing open (non-false positive) ticket that was severity 2, then changed to severity 3
- [x] Verified that a notification was generated for an existing open (non-false positive) ticket that had `kev = false`, then changed to `kev = true`
- [x] Verified that a notification was generated for a closed ticket that was severity 2, then re-opened as a severity 3
- [x] Verified that a notification was generated for a closed ticket ticket that had `kev = false`, then re-opened with `kev = true`

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.