### PR TITLE
Add logging to the cyhy-nvdsync and cyhy-kevsync scripts

### DIFF
--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -17,6 +17,7 @@ Options:
 
 # standard python libraries
 import json
+import logging
 from StringIO import StringIO
 import urllib
 
@@ -86,17 +87,20 @@ def process_url(db, url):
 
 
 def main():
-    args = docopt(__doc__, version="v0.0.1")
+    try:
+        args = docopt(__doc__, version="v0.0.1")
 
-    db = database.db_from_config(args["--section"])
+        db = database.db_from_config(args["--section"])
 
-    if args["--local-file"]:
-        imported_cves = process_file(db, args["<json-file>"])
-    else:
-        imported_cves = process_url(db, KEV_URL)
+        if args["--local-file"]:
+            imported_cves = process_file(db, args["<json-file>"])
+        else:
+            imported_cves = process_url(db, KEV_URL)
 
-    if imported_cves:
-        remove_outdated(db, imported_cves)
+        if imported_cves:
+            remove_outdated(db, imported_cves)
+    except:
+        logging.exception("Unexpected exception")
 
 
 if __name__ == "__main__":

--- a/bin/cyhy-nvdsync
+++ b/bin/cyhy-nvdsync
@@ -20,6 +20,7 @@ Options:
 # standard python libraries
 import gzip
 import json
+import logging
 import urllib
 from StringIO import StringIO
 
@@ -77,19 +78,22 @@ def generate_urls():
 
 
 def main():
-    args = docopt(__doc__, version="v0.0.1")
+    try:
+        args = docopt(__doc__, version="v0.0.1")
 
-    db = database.db_from_config(args["--section"])
+        db = database.db_from_config(args["--section"])
 
-    if args["--use-network"]:
-        urls = generate_urls()
-        for url in urls:
-            print "-" * 10, url, "-" * 10
-            process_url(db, url)
-    else:
-        for filename in args["<file>"]:
-            print "-" * 10, filename, "-" * 10
-            process_file(db, filename, gzipped=args["--gzipped"])
+        if args["--use-network"]:
+            urls = generate_urls()
+            for url in urls:
+                print "-" * 10, url, "-" * 10
+                process_url(db, url)
+        else:
+            for filename in args["<file>"]:
+                print "-" * 10, filename, "-" * 10
+                process_file(db, filename, gzipped=args["--gzipped"])
+    except:
+        logging.exception("Unexpected exception")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds standard Python logging to the `cyhy-nvdsync` and `cyhy-kevsync` scripts, particularly for uncaught exceptions.

## 💭 Motivation and context ##

By logging a message for any uncaught exceptions, we are able to trigger AWS CloudWatch metric alarms via the code in `terraform/nvdsync_failure_alarms.tf` and `terraform/kevsync_failure_alarms.tf` of cisagov/cyhy_amis#394 whenever either of these scripts fails.

Contributes to the resolution of cisagov/cyhy-system#37.  See also:
- cisagov/cyhy_amis#394
- cisagov/cyhy_amis#396
- cisagov/cyhy_amis#397

## 🧪 Testing ##

I ran each scripts locally and verified that the expected log message was emitted upon failure.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.