### PR TITLE
Support CVSSv3 scores and severities

### DIFF
--- a/bin/cyhy-nvdsync
+++ b/bin/cyhy-nvdsync
@@ -43,8 +43,8 @@ def parse_json(db, json_stream):
 
     for entry in data.get("CVE_Items", []):
         cve_id = entry["cve"]["CVE_data_meta"]["ID"]
+        # Reject CVEs that don't have baseMetricV2 or baseMetricV3 CVSS data
         if ("baseMetricV2" or "baseMetricV3") not in entry["impact"]:
-            # Reject CVEs that don't have baseMetricV2 or baseMetricV3 CVSS data
             # Make sure they are removed from our db.
             db.CVEDoc.collection.remove({"_id": cve_id}, safe=False)
             print "x",

--- a/bin/cyhy-nvdsync
+++ b/bin/cyhy-nvdsync
@@ -43,15 +43,24 @@ def parse_json(db, json_stream):
 
     for entry in data.get("CVE_Items", []):
         cve_id = entry["cve"]["CVE_data_meta"]["ID"]
-        if "baseMetricV2" not in entry["impact"]:
-            # NVD 'reject' CVEs do not have 'baseMetricV2' CVSS data
+        if ("baseMetricV2" or "baseMetricV3") not in entry["impact"]:
+            # Reject CVEs that don't have baseMetricV2 or baseMetricV3 CVSS data
             # Make sure they are removed from our db.
             db.CVEDoc.collection.remove({"_id": cve_id}, safe=False)
             print "x",
         else:
             print ".",
-            cvss_base_score = entry["impact"]["baseMetricV2"]["cvssV2"]["baseScore"]
-            entry_doc = db.CVEDoc({"_id": cve_id, "cvss_score": float(cvss_base_score)})
+            if "baseMetricV3" in entry["impact"]:
+                cvss_base_score = entry["impact"]["baseMetricV3"]["cvssV3"]["baseScore"]
+                cvss_version = entry["impact"]["baseMetricV3"]["cvssV3"]["version"]
+            else:
+                cvss_base_score = entry["impact"]["baseMetricV2"]["cvssV2"]["baseScore"]
+                cvss_version = entry["impact"]["baseMetricV2"]["cvssV2"]["version"]
+            entry_doc = db.CVEDoc({
+                "_id": cve_id,
+                "cvss_score": float(cvss_base_score),
+                "cvss_version": cvss_version
+            })
             entry_doc.save(safe=False)
     print "\n\n"
 

--- a/bin/cyhy-nvdsync
+++ b/bin/cyhy-nvdsync
@@ -50,12 +50,9 @@ def parse_json(db, json_stream):
             print "x",
         else:
             print ".",
-            if "baseMetricV3" in entry["impact"]:
-                cvss_base_score = entry["impact"]["baseMetricV3"]["cvssV3"]["baseScore"]
-                cvss_version = entry["impact"]["baseMetricV3"]["cvssV3"]["version"]
-            else:
-                cvss_base_score = entry["impact"]["baseMetricV2"]["cvssV2"]["baseScore"]
-                cvss_version = entry["impact"]["baseMetricV2"]["cvssV2"]["version"]
+            version = "V3" if "baseMetricV3" in entry["impact"] else "V2"
+            cvss_base_score = entry["impact"]["baseMetric" + version]["cvss" + version]["baseScore"]
+            cvss_version = entry["impact"]["baseMetric" + version]["cvss" + version]["version"]
             entry_doc = db.CVEDoc({
                 "_id": cve_id,
                 "cvss_score": float(cvss_base_score),

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1582,15 +1582,26 @@ class CVEDoc(RootDoc):
 
     def save(self, *args, **kwargs):
         # Calculate severity from cvss on save
+        # Source: https://nvd.nist.gov/vuln-metrics/cvss
         cvss = self["cvss_score"]
-        if cvss == 10:
-            self["severity"] = 4
-        elif cvss >= 7.0:
-            self["severity"] = 3
-        elif cvss >= 4.0:
-            self["severity"] = 2
-        else:
-            self["severity"] = 1
+        if self["cvss_version"] == "2.0":
+            if cvss == 10:
+                self["severity"] = 4
+            elif cvss >= 7.0:
+                self["severity"] = 3
+            elif cvss >= 4.0:
+                self["severity"] = 2
+            else:
+                self["severity"] = 1
+        elif self["cvss_version"] in ["3.0", "3.1"]:
+            if cvss >= 9.0:
+                self["severity"] = 4
+            elif cvss >= 7.0:
+                self["severity"] = 3
+            elif cvss >= 4.0:
+                self["severity"] = 2
+            else:
+                self["severity"] = 1
         super(CVEDoc, self).save(*args, **kwargs)
 
 

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1583,6 +1583,19 @@ class CVEDoc(RootDoc):
     def save(self, *args, **kwargs):
         # Calculate severity from cvss on save
         # Source: https://nvd.nist.gov/vuln-metrics/cvss
+        #
+        # Notes:
+        # - The CVSS score to severity mapping is not continuous (e.g. a
+        #   score of 8.95 is undefined according to their table).  However,
+        #   the CVSS equation documentation
+        #   (https://www.first.org/cvss/specification-document#CVSS-v3-1-Equations)
+        #   specifies that all CVSS scores are rounded up to the nearest tenth
+        #   of a point, so our severity mapping below is valid.
+        # - CVSSv3 specifies that a score of 0.0 has a severity of "None", but
+        #   we have chosen to map 0.0 to severity 1 ("Low") because CyHy code
+        #   has historically assumed severities between 1 and 4 (inclusive).
+        #   Since we have not seen CVSSv3 scores lower than 3.1, this will
+        #   hopefully never be an issue.
         cvss = self["cvss_score"]
         if self["cvss_version"] == "2.0":
             if cvss == 10:

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1568,8 +1568,13 @@ class SnapshotDoc(RootDoc):
 
 class CVEDoc(RootDoc):
     __collection__ = CVE_COLLECTION
-    structure = {"_id": basestring, "cvss_score": float, "severity": int}  # CVE String
-    required_fields = ["_id", "cvss_score", "severity"]
+    structure = {
+        "_id": basestring,  # CVE string
+        "cvss_score": float,
+        "cvss_version": basestring,
+        "severity": int
+    }
+    required_fields = ["_id", "cvss_score", "cvss_version", "severity"]
     default_values = {}
 
     def get_indices(self):

--- a/cyhy/db/ticket_manager.py
+++ b/cyhy/db/ticket_manager.py
@@ -125,6 +125,19 @@ class VulnTicketManager(object):
         if new_details["score_source"] != "nvd":
             cvss = new_details["cvss_base_score"]
             # Source: https://nvd.nist.gov/vuln-metrics/cvss
+            #
+            # Notes:
+            # - The CVSS score to severity mapping is not continuous (e.g. a
+            #   score of 8.95 is undefined according to their table).
+            #   However, the CVSS equation documentation
+            #   (https://www.first.org/cvss/specification-document#CVSS-v3-1-Equations)
+            #   specifies that all CVSS scores are rounded up to the nearest
+            #   tenth of a point, so our severity mapping below is valid.
+            # - CVSSv3 specifies that a score of 0.0 has a severity of "None",
+            #   but we have chosen to map 0.0 to severity 1 ("Low") because
+            #   CyHy code has historically assumed severities between 1 and 4
+            #   (inclusive).  Since we have not seen CVSSv3 scores lower than
+            #   3.1, this will hopefully never be an issue.
             if new_details["cvss_version"] == "2":
                 if cvss == 10:
                     new_details["severity"] = 4

--- a/cyhy/db/ticket_manager.py
+++ b/cyhy/db/ticket_manager.py
@@ -96,7 +96,8 @@ class VulnTicketManager(object):
 
         new_details = {
             "cve": vuln.get("cve"),
-            "cvss_base_score": vuln["cvss_base_score"],
+            "cvss_base_score": vuln.get("cvss3_base_score", vuln["cvss_base_score"]),
+            "cvss_version": "3" if "cvss3_base_score" in vuln else "2",
             "kev": False,
             "name": vuln["plugin_name"],
             "score_source": vuln["source"],
@@ -108,6 +109,7 @@ class VulnTicketManager(object):
             cve_doc = self.__db.CVEDoc.find_one({"_id": vuln["cve"]})
             if cve_doc:
                 new_details["cvss_base_score"] = cve_doc["cvss_score"]
+                new_details["cvss_version"] = cve_doc["cvss_version"]
                 new_details["score_source"] = "nvd"
                 new_details["severity"] = cve_doc["severity"]
             # if the CVE is listed in the KEV collection, we'll mark it as such


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds support for [CVSS](https://nvd.nist.gov/vuln-metrics/cvss) v3 scores by importing them from the NVD.  It also appropriately sets the severity of each CVE based on the v2 or v3 scoring system.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Since CVSS v3 has been out for quite a while now, it's about time that we support it.

This PR updates `cyhy-nvdsync` to import data for any CVE that has either v2 or v3 score.  Previously, we only imported the v2 score.

If a v3 score is present in the NVD data, that score is imported into the DB.  If no v3 score is present, the v2 score is imported.  In either case, the version of the CVSS score is now stored in the DB along with the score itself.

Resolves:
* https://github.com/cisagov/cyhy-system/issues/60
* https://github.com/cisagov/cyhy-system/issues/64

This is part of the work for https://github.com/cisagov/cyhy-system/issues/59.

Marking this PR as blocked until the CyHy team allows us to deploy it.  Note that this PR should be deployed in conjunction with https://github.com/cisagov/cyhy-reports/pull/76.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To test the updated `cyhy-nvdsync` code (https://github.com/cisagov/cyhy-core/pull/69/commits/1ad23ec828c956bcce38a39da52d18ae04bf3b3d and https://github.com/cisagov/cyhy-core/pull/69/commits/d5e722e2a9ca630064e02d7d6a5c8f354c98538d), I ran it in my test environment and validated the following things:
* The script ran without error and took the roughly same amount of time as it took before these code changes.
* Every CVE that was imported received a `cvss_version` value (either "2.0", "3.0", or "3.1").
* CVEs were getting assigned the correct severities, i.e. a CVE scored as a 9.0 in CVSS 2.0 got severity 3 (High), while a CVE scored as a 9.0 in CVSS 3.0 or 3.1 got severity 4 (Critical).
* The same number of CVEs were imported both before (when it only imported CVSSv2 scores) and after these code changes.  That isn't a 100% guarantee, but it's a good sign.

To test the updated `ticket_manager.py` code (https://github.com/cisagov/cyhy-core/pull/69/commits/2b81487cd5dd6c1a8e54538254629bc30fb1c980 and https://github.com/cisagov/cyhy-core/pull/69/commits/79d29f5c7e2a515aa8c465265e6f6889334fd987), I deployed the code changes to my test environment and re-ran vulnerability scans for some hosts that previously had open tickets.  I verified that their tickets were correctly updated with the new expected values for `details.cvss_base_score`, `details.cvss_version`, and `details.severity`.  I also confirmed that no tickets were updated with unexpected or erroneous details.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Coordinate deployment plan with CyHy team.
- [x] Deploy these changes to Production.
