### PR TITLE
Add VPR score (if available) to ticket details

### DIFF
--- a/cyhy/db/ticket_manager.py
+++ b/cyhy/db/ticket_manager.py
@@ -101,6 +101,7 @@ class VulnTicketManager(object):
             "name": vuln["plugin_name"],
             "score_source": vuln["source"],
             "severity": vuln["severity"],
+            "vpr_score": vuln.get("vpr_score"),
         }
 
         if "cve" in vuln:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the [Vulnerability Priority Rating (VPR)](https://docs.tenable.com/tenablesc/Content/RiskMetrics.htm#Vulnerability-Priority-Rating-) score to the CyHy ticket details, if the VPR score is present in the vulnerability scan document.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is part of the work for https://github.com/cisagov/cyhy-system/issues/59.

Note that the VPR score is only available from [Nessus 8.14.0](https://docs.tenable.com/releasenotes/Content/nessus/nessus8140.htm) or later.

* Resolves https://github.com/cisagov/cyhy-system/issues/61.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

To test this, I deployed this code to my test environment (which includes a vulnscan instance running Nessus 8.15.4) and re-ran vulnerability scans for some vulnerable hosts.  I verified that when the scans completed, all of the updated tickets included the new `details.vpr_score` field, as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
