### PR TITLE
Correctly reference `IPSet`

### DIFF
--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -112,7 +112,7 @@ def import_request(db, request, source, force=False, init_stage=None):
         print "and replace it with the imported version."
         return False
     request["period_start"] = dateutil.parser.parse(request["period_start"])
-    nets = netaddr.IPSet(request["networks"])
+    nets = IPSet(request["networks"])
     if init_stage:
         request["init_stage"] = init_stage
     if has_intersections(db, nets, source, owner):


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR fixes a bug by correctly referencing `IPSet()` instead of `netaddr.IPSet()`. 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When the `netaddr` import was modified in https://github.com/cisagov/cyhy-core/commit/a17267a2ccaf56f4e3ad51ccffbd2e8674e023f7, we overlooked changing this reference to `IPSet`.  Without this change, you will get:  `NameError: global name 'netaddr' is not defined`

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that this code change allowed me to run `cyhy-import` and have it run correctly and without the `NameError: global name 'netaddr' is not defined` that I was getting previously.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.