### PR TITLE
Correct CVSS validation logic in the `cyhy-nvdsync` script

### DIFF
--- a/bin/cyhy-nvdsync
+++ b/bin/cyhy-nvdsync
@@ -44,7 +44,7 @@ def parse_json(db, json_stream):
     for entry in data.get("CVE_Items", []):
         cve_id = entry["cve"]["CVE_data_meta"]["ID"]
         # Reject CVEs that don't have baseMetricV2 or baseMetricV3 CVSS data
-        if ("baseMetricV2" or "baseMetricV3") not in entry["impact"]:
+        if not any(k in entry["impact"] for k in ["baseMetricV2", "baseMetricV3"]):
             # Make sure they are removed from our db.
             db.CVEDoc.collection.remove({"_id": cve_id}, safe=False)
             print "x",


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request corrects an issue with the [logic to validate CVSS data](https://github.com/cisagov/cyhy-core/blob/073798ff43413a0d78614eb5ff5c2e8ff4adcb0a/bin/cyhy-nvdsync#L47) in the `cyhy-nvdsync` script.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The current logic will not provide an expected result if the list it is checking has a single element. This results in numerous CVE entries failing validation when they should be imported. As an example the 2023 feed only has a single CVE imported out of 3,229 total CVE records with the current logic.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I wrote a [test script](https://gist.github.com/mcdonnnj/7e4f550568a4c07a2e24b3d5885b5706) to validate functionality.

Current logic:

```console
Year | Total  | Failed | Bug
2002 :   6769 :    100 :      0
2003 :   1553 :     50 :      0
2004 :   2707 :     63 :      0
2005 :   4765 :    141 :      0
2006 :   7142 :    151 :      2
2007 :   6579 :    124 :      2
2008 :   7174 :    173 :      3
2009 :   5028 :    127 :      5
2010 :   5199 :    161 :      7
2011 :   4834 :    232 :      4
2012 :   5846 :    427 :     11
2013 :   6695 :    549 :     19
2014 :   8960 :    640 :     68
2015 :   8692 :    760 :     95
2016 :  10536 :   1317 :     39
2017 :  16885 :   2387 :    138
2018 :  16935 :   1281 :     44
2019 :  16868 :   1441 :     46
2020 :  20026 :   1863 :    295
2021 :  21496 :   1479 :    857
2022 :  22473 :  13609 :  13095
2023 :   3229 :   3228 :   2957
```

This logic in this branch:

```console
Year | Total  | Failed | Bug
2002 :   6769 :    100 :      0
2003 :   1553 :     50 :      0
2004 :   2707 :     63 :      0
2005 :   4765 :    141 :      0
2006 :   7142 :    149 :      0
2007 :   6579 :    122 :      0
2008 :   7174 :    170 :      0
2009 :   5028 :    122 :      0
2010 :   5199 :    154 :      0
2011 :   4834 :    228 :      0
2012 :   5846 :    416 :      0
2013 :   6695 :    530 :      0
2014 :   8960 :    572 :      0
2015 :   8692 :    665 :      0
2016 :  10536 :   1278 :      0
2017 :  16885 :   2249 :      0
2018 :  16935 :   1237 :      0
2019 :  16868 :   1395 :      0
2020 :  20026 :   1568 :      0
2021 :  21496 :    622 :      0
2022 :  22473 :    514 :      0
2023 :   3229 :    271 :      0
```
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
