### PR TITLE
Upgrade base Docker image to Debian Buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ RUN apt-get install -y --no-install-recommends \
     python-yaml
 
 # Install MongoDB shell from official repository
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
-RUN echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main" | tee /etc/apt/sources.list.d/mongodb-org-4.0.list
-RUN echo "deb http://deb.debian.org/debian stretch-backports main" | tee /etc/apt/sources.list.d/stretch-backports.list
+RUN curl --fail --silent --show-error --location https://pgp.mongodb.com/server-4.2.asc | \
+    gpg --output /usr/share/keyrings/mongodb-server-4.2.gpg --dearmor
+RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-4.2.gpg ] http://repo.mongodb.org/apt/debian buster/mongodb-org/4.2 main" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list
 RUN apt-get update && apt-get install -y mongodb-org-shell
 
 # Clean up the apt cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # NOTE: Be careful- you really don't want to push this Docker image to the
 # public Docker Hub if it was built with your MaxMind license key!
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 LABEL maintainer="Mark Feldhousen <mark.feldhousen@cisa.dhs.gov>"
 LABEL description="Docker image to provide tools for interacting with the CyHy \
 production database."


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades the base Docker image used in `Dockerfile` from Debian Stretch to Debian Buster.

## 💭 Motivation and context ##

Stretch is no longer supported by Debian, as the [upstream package repositories have been archived](https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html).

Resolves #76.

## 🧪 Testing ##

I was able to successfully build the Docker image locally.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
