### PR TITLE
Add the `id_update.py` script used to re-ID stakeholders

### DIFF
--- a/extras/id_update.py
+++ b/extras/id_update.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+"""Change the _id and acronym of an organization across all CyHy database collections.
+
+Usage:
+  id_update.py [options] OLD_OWNER NEW_OWNER
+  id_update.py (-h | --help)
+  id_update.py --version
+
+Options:
+  -h --help                      Show this screen.
+  --version                      Show version.
+  -s SECTION --section=SECTION   Configuration section to use.
+
+"""
+
+import sys
+from docopt import docopt
+from cyhy.db import database
+from cyhy.util import util
+
+
+def main():
+    args = docopt(__doc__, version="v0.0.1")
+    db = database.db_from_config(args["--section"])
+    old_owner = args["OLD_OWNER"]
+    new_owner = args["NEW_OWNER"]
+
+    if not util.warn_and_confirm("This will modify database documents."):
+        print >> sys.stderr, "Aborted."
+        sys.exit(-2)
+    print >> sys.stderr
+
+    # cannot replace _id...so must save and remove old doc
+    # store the document in a variable
+    for collection in (db.requests, db.tallies):
+        doc = collection.find_one({"_id": old_owner})
+        if doc == None:
+            if collection == db.tallies:
+                print >> sys.stderr, "WARNING: Organization does not have a tally document."
+                break
+            print >> sys.stderr, "ERROR: Organization does not have a request document."
+            sys.exit(-1)
+        if collection.find_one({"_id": new_owner}):
+            print >> sys.stderr, "ERROR: An organization with _id {} exists.".format(
+                new_owner
+            )
+            sys.exit(-1)
+        # set a new _id on the document
+        doc["_id"] = new_owner
+        # insert the document, using the new _id
+        collection.insert(doc)
+        # remove the document with the old _id
+        collection.remove({"_id": old_owner})
+        print "  1 {} document modified".format(collection.name)
+
+    db.requests.update(
+        {"_id": new_owner},
+        {"$set": {"agency.acronym": new_owner}},
+        upsert=False,
+        multi=False,
+        safe=True,
+    )
+
+    for collection in (
+        db.host_scans,
+        db.hosts,
+        db.port_scans,
+        db.snapshots,
+        db.tickets,
+        db.vuln_scans,
+        db.reports,
+    ):
+        result = collection.update(
+            {"owner": old_owner},
+            {"$set": {"owner": new_owner}},
+            upsert=False,
+            multi=True,
+            safe=True,
+        )
+        result["collection"] = collection.name
+        print "  {nModified} {collection} documents modified".format(**result)
+
+    # Update all request docs that have OLD_OWNER in their list of children; remove OLD_OWNER then add NEW_OWNER
+    for request_doc in db.RequestDoc.find({"children": old_owner}):
+        request_doc["children"].remove(old_owner)
+        request_doc["children"].append(new_owner)
+        request_doc.save()
+        print "  Updated list of children in {} request document".format(
+            request_doc["_id"]
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds the `id_update.py` script we use to re-ID stakeholders to the project.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This script is one we use semi-regularly to re-ID stakeholders when needed. It is added to the `extras/` directory until the functionality is integrated either into an existing `cyhy-*` command, its own command, or its need is rendered obsolete. Storing it in this project will improve the visibility/tracking of the script and make it easier to integrate into automatic deployments.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

What's that? Joking aside this script sees regular use and it is being added with no modifications from the private repository that currently houses the script.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
