### PR TITLE
More thoroughly prevent non-ASCII from ending up in the MongoDB database

### DIFF
--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -171,7 +171,7 @@ def import_stdin(db, force, init_stage=None):
 
 
 def main():
-    args = docopt(__doc__, version="v0.0.1")
+    args = docopt(__doc__, version="v0.0.2")
     db = database.db_from_config(args["--section"])
 
     if args["FILE"] != None:

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -160,7 +160,13 @@ def import_file(db, filename, force, init_stage=None):
 
 
 def import_stdin(db, force, init_stage=None):
-    request = json.load(sys.stdin)
+    try:
+        # This would need to be changed for py3
+        request = json.load(sys.stdin, encoding="ascii")
+    except UnicodeDecodeError as e:
+        print ("Document contains a non-ASCII character: {}".format(e))
+        return False
+
     return import_request(db, request, "from stdin", force, init_stage)
 
 

--- a/bin/cyhy-simple
+++ b/bin/cyhy-simple
@@ -213,7 +213,7 @@ def fill_in(db, file_pointer, force=False):
 
 
 def main():
-    args = docopt(__doc__, version="v0.0.2")
+    args = docopt(__doc__, version="v0.0.3")
 
     if args["--blank"]:
         write_blank_config()

--- a/bin/cyhy-simple
+++ b/bin/cyhy-simple
@@ -18,6 +18,7 @@ Options:
   -s SECTION --section=SECTION   Configuration section to use.
 """
 
+import codecs
 import sys
 import os
 from docopt import docopt
@@ -96,10 +97,10 @@ def get_location_details(db, gnis_id):
         sys.exit(-1)
 
 
-def fill_in(db, filename, force=False):
+def fill_in(db, file_pointer, force=False):
     request = db.RequestDoc()
     config = SafeConfigParser(allow_no_value=True)
-    config.read([filename])
+    config.readfp(file_pointer)
     # import IPython; IPython.embed() #<<< BREAKPOINT >>>
 
     request["period_start"] = THE_VERY_DISTANT_FUTURE
@@ -226,7 +227,12 @@ def main():
         print >> sys.stderr, "File not found:", args["FILENAME"]
         sys.exit(-1)
 
-    request = fill_in(db, args["FILENAME"], force)
+    try:
+        with codecs.open(args["FILENAME"], "r", encoding="ascii") as in_file:
+            request = fill_in(db, in_file, force)
+    except UnicodeDecodeError as e:
+        print >> sys.stderr, "Document contains a non-ASCII character: {}".format(e)
+        sys.exit(-1)
 
     if args["--networks"]:
         for n in request["networks"]:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull requests add checking for non-ASCII characters in the `cyhy-simple` script and expands existing checking in the `cyhy-import` script to include reading from standard input. I also bump the versions of the respective scripts to go along with these changes to functionality.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When non-ASCII characters end up in the MongoDB database it will cause issues when other CyHy components (like [cyhy-reports](https://github.com/cisagov/cyhy-reports)) to fail when interacting with this data. This is a result of how strings are handled in Python 2 and the fact that we do not use Unicode strings (this is explicitly required in Python 2 vs. implicit in Python 3).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I confirmed that I was unable to convert an INI formatted file that contained non-ASCII characters with the `cyhy-simple` script. I then re-confirmed that I could not import a JSON containing non-ASCII when passed as a file to `cyhy-import` and received the same error when attempting to import the file passing it in through standard input.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
