### PR TITLE
Ingest "known ransomware" data in KEV feed

### DIFF
--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -56,15 +56,14 @@ def parse_json(db, json_stream):
             raise ValueError("JSON does not look like valid CISA KEV data.")
         else:
             if i.get("knownRansomwareCampaignUse", "").lower() == "known":
-                kevs.append({"cve_id": cve_id, "known_ransomware": True})
+                kevs.append({"_id": cve_id, "known_ransomware": True})
                 known_ransomware_count += 1
             else:
-                kevs.append({"cve_id": cve_id, "known_ransomware": False})
+                kevs.append({"_id": cve_id, "known_ransomware": False})
 
     # Insert a KEV document for each CVE
     for kev in kevs:
-        entry_doc = db.KEVDoc({"_id": kev["cve_id"],
-            "known_ransomware": kev["known_ransomware"]})
+        entry_doc = db.KEVDoc(kev)
         entry_doc.save(safe=False)
 
     all_cve_ids = set([i["cve_id"] for i in kevs])

--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -49,19 +49,26 @@ def parse_json(db, json_stream):
 
     # Gather all the cveIDs from the JSON file
     all_cve_ids = set()
+    known_ransomware_use_ids = set()
     for i in data["vulnerabilities"]:
         cve_id = i.get("cveID")
         if not cve_id:
             raise ValueError("JSON does not look like valid CISA KEV data.")
         else:
             all_cve_ids.add(cve_id)
+            if i.get("knownRansomwareCampaignUse").lower() == "known":
+                known_ransomware_use_ids.add(cve_id)
 
     # Insert a KEV document for each CVE
     for cve in all_cve_ids:
-        entry_doc = db.KEVDoc({"_id": cve})
+        if cve in known_ransomware_use_ids:
+            entry_doc = db.KEVDoc({"_id": cve, "known_ransomware": True})
+        else:
+            entry_doc = db.KEVDoc({"_id": cve, "known_ransomware": False})
         entry_doc.save(safe=False)
 
-    print("Imported %d KEV entries." % len(all_cve_ids))
+    print("Imported %d KEV entries, %d are known ransomware." % (
+        len(all_cve_ids), len(known_ransomware_use_ids)))
     if data.get("count"):
         if data["count"] != len(all_cve_ids):
             print(

--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -47,28 +47,29 @@ def parse_json(db, json_stream):
     data = json.load(json_stream)
     json_stream.close()
 
-    # Gather all the cveIDs from the JSON file
-    all_cve_ids = set()
-    known_ransomware_use_ids = set()
+    # Gather cveID and knownRansomwareCampaignUse data from the JSON file
+    kevs = []
+    known_ransomware_count = 0
     for i in data["vulnerabilities"]:
         cve_id = i.get("cveID")
         if not cve_id:
             raise ValueError("JSON does not look like valid CISA KEV data.")
         else:
-            all_cve_ids.add(cve_id)
             if i.get("knownRansomwareCampaignUse").lower() == "known":
-                known_ransomware_use_ids.add(cve_id)
+                kevs.append({"cve_id": cve_id, "known_ransomware": True})
+                known_ransomware_count += 1
+            else:
+                kevs.append({"cve_id": cve_id, "known_ransomware": False})
 
     # Insert a KEV document for each CVE
-    for cve in all_cve_ids:
-        if cve in known_ransomware_use_ids:
-            entry_doc = db.KEVDoc({"_id": cve, "known_ransomware": True})
-        else:
-            entry_doc = db.KEVDoc({"_id": cve, "known_ransomware": False})
+    for kev in kevs:
+        entry_doc = db.KEVDoc({"_id": kev["cve_id"],
+            "known_ransomware": kev["known_ransomware"]})
         entry_doc.save(safe=False)
 
+    all_cve_ids = set([i["cve_id"] for i in kevs])
     print("Imported %d KEV entries, %d are known ransomware." % (
-        len(all_cve_ids), len(known_ransomware_use_ids)))
+        len(all_cve_ids), known_ransomware_count))
     if data.get("count"):
         if data["count"] != len(all_cve_ids):
             print(

--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -66,7 +66,7 @@ def parse_json(db, json_stream):
         entry_doc = db.KEVDoc(kev)
         entry_doc.save(safe=False)
 
-    all_cve_ids = set([i["cve_id"] for i in kevs])
+    all_cve_ids = set(i["_id"] for i in kevs)
     print("Imported %d KEV entries, %d are known ransomware." % (
         len(all_cve_ids), known_ransomware_count))
     if data.get("count"):

--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -55,7 +55,7 @@ def parse_json(db, json_stream):
         if not cve_id:
             raise ValueError("JSON does not look like valid CISA KEV data.")
         else:
-            if i.get("knownRansomwareCampaignUse").lower() == "known":
+            if i.get("knownRansomwareCampaignUse", "").lower() == "known":
                 kevs.append({"cve_id": cve_id, "known_ransomware": True})
                 known_ransomware_count += 1
             else:

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1719,7 +1719,7 @@ class NotificationDoc(RootDoc):
 
 class KEVDoc(RootDoc):
     __collection__ = KEV_COLLECTION
-    structure = {"_id": basestring}
+    structure = {"_id": basestring, "known_ransomware": bool}
     required_fields = ["_id"]
     default_values = {}
 

--- a/cyhy/db/ticket_manager.py
+++ b/cyhy/db/ticket_manager.py
@@ -99,6 +99,7 @@ class VulnTicketManager(object):
             "cvss_base_score": vuln.get("cvss3_base_score", vuln["cvss_base_score"]),
             "cvss_version": "3" if "cvss3_base_score" in vuln else "2",
             "kev": False,
+            "kev_ransomware": False,
             "name": vuln["plugin_name"],
             "score_source": vuln["source"],
             "severity": vuln["severity"],
@@ -117,6 +118,8 @@ class VulnTicketManager(object):
             kev_doc = self.__db.KEVDoc.find_one({"_id": vuln["cve"]})
             if kev_doc:
                 new_details["kev"] = True
+                if kev_doc.get("known_ransomware"):
+                    new_details["kev_ransomware"] = True
 
         # As of May 2022, some Nessus plugins report a severity that is
         # inconsistent with their (non-NVD, non-CVE-based) CVSS v3 score.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates `cyhy-kevsync` to read the recently-added `knownRansomwareCampaignUse` field from the [CISA JSON `known_exploited_vulnerabilities_schema`](https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities_schema.json) and store it in the CyHy `KEVDoc` database collection.

Additionally, this PR updates the ticket manager to be aware of the new `known_ransomware` flag in the ticket details (see https://github.com/cisagov/cyhy-core/pull/80/commits/d166237ae7a367b7198b36cbdaa9a4a0eda58fb6).  This is in support of the work needed for https://github.com/cisagov/cyhy-system/issues/101 and https://github.com/cisagov/cyhy-system/issues/102.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In support of the "Ransomware Vulnerability Warning Pilot", this data needs to pulled into the CyHy database so that it can be reported to CyHy stakeholders.

Resolves https://github.com/cisagov/cyhy-system/issues/100.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I deployed these changes to a development environment, ran `cyhy-kevsync`, and confirmed that it ran successfully:
```console
$ sudo grep kevsync /var/log/syslog
Oct 19 14:57:03 database1 CRON[28154]: (cyhy) CMD (/usr/local/bin/cyhy-kevsync 2>&1 | /usr/bin/logger -t cyhy-kevsync)
Oct 19 14:57:04 database1 cyhy-kevsync: Imported 1022 KEV entries, 184 are known ransomware.
```

I also checked the database and verified that the new field was being ingested as expected:
```
> db.kevs.findOne()
{ "_id" : "CVE-2019-0841", "known_ransomware" : true }
> db.kevs.count()
1022
> db.kevs.count({"known_ransomware": true})
184
> db.kevs.count({"known_ransomware": false})
838
```

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Deploy changes to production.
