### PR TITLE
Flatten Unicode in GNIS data to ASCII when importing to the databse

### DIFF
--- a/var/GNIS_data_import.py
+++ b/var/GNIS_data_import.py
@@ -14,6 +14,7 @@ Options:
   --force                        Force loading of the provided file.
 
 """
+from __future__ import print_function
 
 import csv
 import re
@@ -30,8 +31,8 @@ POP_PLACES_HEADER = "FEATURE_ID|FEATURE_NAME|FEATURE_CLASS|STATE_ALPHA|STATE_NUM
 
 def exit_if_imported(fname):
     """Exit if the file appears to already have been loaded."""
-    print "EXITING without importing any documents."
-    print "The places collection already has {} loaded.".format(fname)
+    print("EXITING without importing any documents.")
+    print("The places collection already has {} loaded.".format(fname))
     sys.exit(0)
 
 
@@ -193,7 +194,7 @@ def main():
                 db, csv_reader
             )  # IMPORTANT: This import must be done AFTER import_govt_units()
         else:
-            print "ERROR: Unknown header line found in: {}".format(args["PLACES_FILE"])
+            print("ERROR: Unknown header line found in: {}".format(args["PLACES_FILE"]))
             sys.exit(-1)
 
     # import IPython; IPython.embed() #<<< BREAKPOINT >>>

--- a/var/GNIS_data_import.py
+++ b/var/GNIS_data_import.py
@@ -182,7 +182,7 @@ def main():
     db = database.db_from_config(args["--section"])
 
     # Files downloaded from geonames.usgs.gov are UTF8-BOM
-    with io.open(args["PLACES_FILE"], encoding="utf=8=sig") as place_file:
+    with io.open(args["PLACES_FILE"], encoding="utf-8-sig") as place_file:
         csv_reader = csv.DictReader(
             skip_comments(unidecode_lines(place_file)), delimiter="|"
         )

--- a/var/requirements.txt
+++ b/var/requirements.txt
@@ -1,0 +1,2 @@
+docopt
+unidecode


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `var/GNIS_data_import.py` script to flatten any Unicode characters in the imported GNIS data to ASCII using the [Unidecode] package. This resolves #82 and https://github.com/cisagov/cyhy-system/issues/109. Additionally it adds a `vars/requirements.txt` file to track any additional Python package dependencies for the scripts in that directory.

> [!NOTE]
> The [Unidecode] package will need to be installed for this script to function and so this PR is partially reliant on https://github.com/cisagov/ansible-role-cyhy-core/pull/74

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

As this is a legacy Python 2 project we really need purely ASCII data stored in the MongoDB database. Since the GNIS data stays true to accuracy there are a relatively large number of records that contain Unicode characters. Rather than a human manually interpreting the data it makes sense to use a package to flatten in a consistent manner.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this in my development environment in the following way:
1. Imported GNIS data using the current script.
2. Verified that non-ASCII characters are in the database documents by writing a script to pull all places in the database, export them to a file as JSON, and then read the JSON field back in to compare. The script failed with a `UnicodeDecodeError` error as expected.
3. Re-imported GNIS data using this version of the script and the `--force` option.
4. Re-ran the test script and verified that it ran through without any errors.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).

[Unidecode]: https://pypi.org/project/Unidecode/