### PR TITLE
Add `enrolled` date field to CyHy `RequestDoc`

### DIFF
--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -106,11 +106,17 @@ def has_restricted_ips(nets):
 
 def import_request(db, request, source, force=False, init_stage=None):
     owner = request["_id"]
-    if not force and already_exists(db, request):
-        print "Cannot import, owner already exists:", owner
-        print "Use --force to destroy the currently stored document"
-        print "and replace it with the imported version."
-        return False
+    # Check if owner already exists
+    db_request = db.RequestDoc.get_by_owner(owner)
+    if db_request:
+        if not force:
+            print "Cannot import, owner already exists:", owner
+            print "Use --force to destroy the currently stored document"
+            print "and replace it with the imported version."
+            return False
+        # Preserve existing enrollment date if it exists
+        if db_request.get("enrolled"):
+            request["enrolled"] = db_request["enrolled"]
     request["period_start"] = dateutil.parser.parse(request["period_start"])
     nets = IPSet(request["networks"])
     if init_stage:

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -56,13 +56,6 @@ DAYS_OF_WEEK = [
 ]
 
 
-def already_exists(db, request):
-    owner = request["_id"]
-    db_request = db.RequestDoc.get_by_owner(owner)
-    if db_request:
-        return True
-
-
 def print_intersections(intersections):
     for request, cidrs in intersections.iteritems():
         print "%s (%s): %d" % (request["agency"]["name"], request["_id"], len(cidrs))

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1056,6 +1056,7 @@ class RequestDoc(RootDoc):
                 "country_name": basestring,
             },
         },
+        "enrolled": datetime.datetime,
         "period_start": datetime.datetime,
         "windows": [{"duration": int, "start": basestring, "day": basestring}],
         "networks": [CustomIPNetwork()],
@@ -1287,6 +1288,9 @@ class RequestDoc(RootDoc):
             self["agency"]["location"]["gnis_id"] = long(
                 self["agency"]["location"]["gnis_id"]
             )
+        # Set enrollment date if it was not previously set
+        if not self.get("enrolled"):
+            self["enrolled"] = util.utcnow()
         super(RequestDoc, self).save(*args, **kwargs)
 
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a new `enrolled` field to `RequestDoc` and sets it when the document is saved.  The `cyhy-import` script is also modified to preserve the `enrolled` date when an existing `RequestDoc` gets updated via the `--force` flag.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Please also review [this code that I wrote to backfill the enrollment dates of existing entities](https://gist.github.com/dav3r/3b9cd18db5ff34623b5676228b956a9f).

Related documentation PR: https://github.com/cisagov/ncats-data-dictionary/pull/44

Resolves #85.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested the changes to `database.py` and `cyhy-import` in my development environment by importing:

1. A brand new request doc - result: `enrolled` date was set
2. An existing request doc (without using the `--force` flag) - result: request doc was untouched
3. An existing request doc without an `enrolled` field set (using the `--force` flag) - result: `enrolled` date was set
4. An existing request doc with the `enrolled` field already set (using the `--force` flag) - result: `enrolled` date was not modified

In all cases above, I confirmed that the `enrolled` field was either set correctly or not modified, as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Deploy these changes to Production.
- [x] Ensure CyHy Ops team incorporates these changes into their Docker container.
- [x] Run backfill script to set enrollment dates of existing entities.
