### PR TITLE
Change the base URL used to retrieve GNIS data in the `load_places.sh` script

### DIFF
--- a/var/load_places.sh
+++ b/var/load_places.sh
@@ -36,9 +36,9 @@ DB_SECTION="${1-}"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Base URL for the zip files is derived from the listings at
-# https://www.usgs.gov/core-science-systems/ngp/board-on-geographic-names/download-gnis-data
+# https://www.usgs.gov/us-board-on-geographic-names/download-gnis-data
 # for GOVT_UNITS and POP_PLACES
-DATA_BASE_URL="https://geonames.usgs.gov/docs/stategaz/"
+DATA_BASE_URL="https://prd-tnm.s3.amazonaws.com/StagedProducts/GeographicNames/Archive/TopicalGazetteers/"
 
 TMP_PLACES_DIR="/tmp/places"
 ADDL_PLACES_FILE="../extras/ADDL_CYHY_PLACES.txt"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes the base URL that is used to retrieve GNIS data for import into the database.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The current URL points to a server that will sometimes return a response that the service is unavailable. They now have this same data stored in the Amazon S3 bucket they use to distribute their various datasets. It makes sense to switch to this bucket as it should have no issues with availability compared to the current server.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that I was able to pull in GNIS data in my testing environment when deploying a new database instance. I also downloaded the two versions and verified they matched both in size and SHA256 hash.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
