### PR TITLE
Update `check_restricted_ip()` error-handling code

### DIFF
--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -78,6 +78,6 @@ class GeoLocDB(object):
             if response.country.name in RESTRICTED_COUNTRIES:
                 return response.country.name
         except AddressNotFoundError:
-            print >> sys.stderr, "CIDR %s not found in geolocation database" % cidr
+            print >> sys.stderr, "IP %s not found in geolocation database" % ip
 
         return ""


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR fixes a bug in the error handling code of the `check_restricted_ip()` function.


## 💭 Motivation and context ##

This bug prevents us from being able to add IPs that don't exist in our geoIP DB.

Resolves #92.

## 🧪 Testing ##

I tested the changes to `geoloc.py` in my development environment by:
1. Running the `cyhy-ip` command below against IP addresses that don't exist in the geoIP DB
2. Comparing the results against past results; verifying the correct results
3. Running the `cyhy-ip` command below against other IP addresses and CIDRs to assure the results provided the expected results

Expected results verified:
```
cyhy-ip add TEST_ENTITY <IP address>
IPs added to request, and initialized.  Tally sync required to start scan of new IPs.▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶▶| ETA:  0:00:00
```

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.


## ✅ Post-merge checklist ##

- [ ] Notify team to update local cyhy-core image.
