### PR TITLE
Add location flag to `curl` command

### DIFF
--- a/var/geoipupdate.sh
+++ b/var/geoipupdate.sh
@@ -40,4 +40,4 @@ GEOIP_CITY_DIR="/usr/local/share/GeoIP/"
 
 mkdir -p "$GEOIP_CITY_DIR"
 
-curl "$GEOIP_CITY_URI" | tar zxf - --strip-components=1 --directory="$GEOIP_CITY_DIR"
+curl --location "$GEOIP_CITY_URI" | tar zxf - --strip-components=1 --directory="$GEOIP_CITY_DIR"


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `--location` flag to the `curl` command used in `var/geoipupdate.sh`.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Resolves #96.

Without this, the request to fetch the GeoIP database fails because `curl` does not follow the redirect specified by the HTTP 302 response.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I confirmed that without this change, `generate_cyhy_docker_image.sh` fails with the error shown in #96.  After this change, the script runs successfully and a `cyhy-core` Docker image is created.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.