### PR TITLE
Fix the Docker configuration and add testing for the configuration on pull requests

### DIFF
--- a/.github/workflows/test-docker-configuration.yml
+++ b/.github/workflows/test-docker-configuration.yml
@@ -70,7 +70,7 @@ jobs:
           # monitor_permissions equal to "true".
           #
           # TODO: Re-enable this functionality when practical.  See
-          # cisagov/ncats-webui#52 for more details.
+          # cisagov/cyhy-core#104 for more details.
           monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the

--- a/.github/workflows/test-docker-configuration.yml
+++ b/.github/workflows/test-docker-configuration.yml
@@ -1,0 +1,94 @@
+---
+name: Test Docker configuration
+
+on:  # yamllint disable-line rule:truthy
+  merge_group:
+    types:
+      - checks_requested
+  pull_request:
+
+# Set a default shell for any run steps. The `-Eueo pipefail` sets errtrace,
+# nounset, errexit, and pipefail. The `-x` will print all commands as they are
+# run. Please see the GitHub Actions documentation for more information:
+# https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs
+defaults:
+  run:
+    shell: bash -Eueo pipefail -x {0}
+
+jobs:
+  diagnostics:
+    name: Run diagnostics
+    # This job does not need any permissions
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      # Note that a duplicate of this step must be added at the top of
+      # each job.
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          check_github_status: "true"
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          output_workflow_context: "true"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+  build:
+    needs:
+      - diagnostics
+    permissions:
+      # actions/checkout needs this to fetch code
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/ncats-webui#52 for more details.
+          monitor_permissions: "false"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Check out the repository
+        uses: actions/checkout@v5
+      - name: Build the Docker configuration
+        run: docker build --tag cisagov/cyhy-core:test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # NOTE: Be careful- you really don't want to push this Docker image to the
 # public Docker Hub if it was built with your MaxMind license key!
 
-FROM debian:buster-slim
+# Official Docker images are in the form library/<app> while non-official
+# images are in the form <user>/<app>.
+FROM docker.io/library/debian:buster-slim
+
 LABEL maintainer="Mark Feldhousen <mark.feldhousen@cisa.dhs.gov>"
 LABEL description="Docker image to provide tools for interacting with the CyHy \
 production database."

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN chown cyhy:cyhy ${CYHY_HOME}
 VOLUME ${CYHY_ETC} ${CYHY_HOME}
 
 ###
-# Remove existing apt SourceList confniguration and add in one configured
+# Remove existing apt SourceList configuration and add in one configured
 # to use the Debian Archive. This is necessary because the Debian Buster
 # apt repository was archived.
 ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,14 @@ RUN mkdir ${CYHY_HOME}
 RUN chown cyhy:cyhy ${CYHY_HOME}
 VOLUME ${CYHY_ETC} ${CYHY_HOME}
 
+###
+# Remove existing apt SourceList confniguration and add in one configured
+# to use the Debian Archive. This is necessary because the Debian Buster
+# apt repository was archived.
+###
+RUN rm /etc/apt/sources.list
+COPY docker/archive.list /etc/apt/sources.list.d/
+
 # Install required packages
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docker/archive.list
+++ b/docker/archive.list
@@ -1,0 +1,3 @@
+deb http://archive.debian.org/debian buster main
+deb http://archive.debian.org/debian buster-updates main
+deb http://archive.debian.org/debian-security buster/updates main

--- a/docker/archive.list
+++ b/docker/archive.list
@@ -1,3 +1,4 @@
 deb http://archive.debian.org/debian buster main
 deb http://archive.debian.org/debian buster-updates main
 deb http://archive.debian.org/debian-security buster/updates main
+deb http://archive.debian.org/debian buster-backports main


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request fixes the Docker configuration so that you can successfully build a Docker image again. This was done by switching the apt SourceList configuration to using the Debian Archive. It also adds the Debian Backports repository to mirror what's available on CyHy instances as well as adds a GitHub Actions workflow to test that a Docker image can be successfully built for pull requests.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

@dav3r noticed that you could not build a Docker image anymore. This is due to the Debian Buster package repositories being removed from the regular apt repository and only being available from the Debian Archive.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that I could successfully build a Docker image with this updated configuration.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
