### PR TITLE
`cyhy-nvdsync` support for NIST NVD JSON v2.0

### DIFF
--- a/bin/cyhy-nvdsync
+++ b/bin/cyhy-nvdsync
@@ -33,6 +33,7 @@ from cyhy.util import util
 
 NVD_URL = "https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-{year}.json.gz"
 NVD_FIRST_YEAR = 2002
+NVD_SOURCE_EMAIL = "nvd@nist.gov"
 
 
 def parse_json(db, json_stream):
@@ -59,18 +60,20 @@ def parse_json(db, json_stream):
             db.CVEDoc.collection.remove({"_id": cve_id}, safe=False)
             print "x",
         else:
-            # Determine newest CVSS metrics version containing a "Primary"
-            # metric in the CVE data
+            # Grab newest CVSS metrics with NVD_SOURCE_EMAIL as the source
             cvss_base_score = None
             cvss_version = None
             try:
                 for v in ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]:
                     if v in entry["cve"].get("metrics", {}):
                         for metric in entry["cve"]["metrics"][v]:
-                            if metric.get("type") == "Primary":
+                            if metric.get("source") == NVD_SOURCE_EMAIL:
                                 cvss_base_score = metric["cvssData"]["baseScore"]
                                 cvss_version = metric["cvssData"]["version"]
                                 break
+                    if cvss_base_score is not None:
+                        # Break out of outer loop
+                        break
 
                 if cvss_base_score is None or cvss_version is None:
                     # Remove CVE (if it exists) from database

--- a/bin/cyhy-nvdsync
+++ b/bin/cyhy-nvdsync
@@ -31,28 +31,49 @@ from docopt import docopt
 from cyhy.db import database
 from cyhy.util import util
 
-NVD_URL = "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-{year}.json.gz"
+NVD_URL = "https://nvd.nist.gov/feeds/json/cve/2.0/nvdcve-2.0-{year}.json.gz"
 NVD_FIRST_YEAR = 2002
 
 
 def parse_json(db, json_stream):
     data = json.load(json_stream)
 
-    if data.get("CVE_data_type") != "CVE":
+    if data.get("format") != "NVD_CVE":
         raise ValueError("JSON does not look like valid NVD CVE data.")
 
-    for entry in data.get("CVE_Items", []):
-        cve_id = entry["cve"]["CVE_data_meta"]["ID"]
-        # Reject CVEs that don't have baseMetricV2 or baseMetricV3 CVSS data
-        if not any(k in entry["impact"] for k in ["baseMetricV2", "baseMetricV3"]):
+    for entry in data.get("vulnerabilities", []):
+        cve_id = entry["cve"]["id"]
+        # Reject CVEs that don't have V2 or V3 CVSS data
+        if not any(k in entry["cve"].get("metrics", {})
+            for k in [
+                "cvssMetricV2",
+                "cvssMetricV30",
+                "cvssMetricV31",
+            ]):
             # Make sure they are removed from our db.
             db.CVEDoc.collection.remove({"_id": cve_id}, safe=False)
             print "x",
         else:
+            # Determine newest CVSS metrics version in the CVE data
+            metrics_version = None
+            for v in ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]:
+                if v in entry["cve"]["metrics"]:
+                    metrics_version = v
+                    break
+
+            for metric in entry["cve"]["metrics"][metrics_version]:
+                if metric["type"] == "Primary":
+                    cvss_base_score = metric["cvssData"]["baseScore"]
+                    cvss_version = metric["cvssData"]["version"]
+                    break
+            else:
+                # No Primary CVSS metric found; remove it from our db
+                db.CVEDoc.collection.remove({"_id": cve_id}, safe=False)
+                print "x",
+                continue
+
             print ".",
-            version = "V3" if "baseMetricV3" in entry["impact"] else "V2"
-            cvss_base_score = entry["impact"]["baseMetric" + version]["cvss" + version]["baseScore"]
-            cvss_version = entry["impact"]["baseMetric" + version]["cvss" + version]["version"]
+            # Upsert CVE document in the database
             entry_doc = db.CVEDoc({
                 "_id": cve_id,
                 "cvss_score": float(cvss_base_score),

--- a/bin/cyhy-nvdsync
+++ b/bin/cyhy-nvdsync
@@ -42,7 +42,12 @@ def parse_json(db, json_stream):
         raise ValueError("JSON does not look like valid NVD CVE data.")
 
     for entry in data.get("vulnerabilities", []):
-        cve_id = entry["cve"]["id"]
+        try:
+            cve_id = entry["cve"]["id"]
+        except KeyError:
+            print "Skipping; invalid JSON - no id found for CVE: " + entry
+            continue
+
         # Reject CVEs that don't have V2 or V3 CVSS data
         if not any(k in entry["cve"].get("metrics", {})
             for k in [
@@ -54,23 +59,26 @@ def parse_json(db, json_stream):
             db.CVEDoc.collection.remove({"_id": cve_id}, safe=False)
             print "x",
         else:
-            # Determine newest CVSS metrics version in the CVE data
-            metrics_version = None
-            for v in ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]:
-                if v in entry["cve"]["metrics"]:
-                    metrics_version = v
-                    break
+            # Determine newest CVSS metrics version containing a "Primary"
+            # metric in the CVE data
+            cvss_base_score = None
+            cvss_version = None
+            try:
+                for v in ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]:
+                    if v in entry["cve"].get("metrics", {}):
+                        for metric in entry["cve"]["metrics"][v]:
+                            if metric.get("type") == "Primary":
+                                cvss_base_score = metric["cvssData"]["baseScore"]
+                                cvss_version = metric["cvssData"]["version"]
+                                break
 
-            for metric in entry["cve"]["metrics"][metrics_version]:
-                if metric["type"] == "Primary":
-                    cvss_base_score = metric["cvssData"]["baseScore"]
-                    cvss_version = metric["cvssData"]["version"]
-                    break
-            else:
-                # No Primary CVSS metric found; remove it from our db
-                db.CVEDoc.collection.remove({"_id": cve_id}, safe=False)
-                print "x",
-                continue
+                if cvss_base_score is None or cvss_version is None:
+                    # Remove CVE (if it exists) from database
+                    db.CVEDoc.collection.remove({"_id": cve_id}, safe=False)
+                    print "x",
+                    continue
+            except KeyError:
+                print "Skipping; invalid JSON for CVE: " + cve
 
             print ".",
             # Upsert CVE document in the database


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the `cyhy-nvdsync` script to use v2.0 of the NIST NVD JSON files.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Previously, this script supported their v1.1 JSON format, but the v1.1 files were decommissioned on Aug. 20, 2025 per the info below from https://www.nist.gov/itl/nvd:

> Decommissioning of Legacy Data Feed Files
>
> As of August 20th, 2025, the following legacy Data Feed files have been removed from the NVD [Data Feeds Page](https://nvd.nist.gov/vuln/data-feeds) and are no longer available for access or download 
>
> - 1.1 Vulnerability Feeds
> - 1.0 CPE Match Feed
> - XML CPE Dictionary Files to include the Official CPE 2.2 and 2.3 Dictionary .zip and .gz
>
> Any organizations making use of the legacy feed files will need to update their systems to use the 2.0 APIs or the 2.0 data feed files. 

Also noted in https://github.com/cisagov/cyhy-core/issues/73#issuecomment-3215272857.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that these changes work as expected by successfully running this version of `cyhy-nvdsync` in a dev environment.  The count of CVE documents in the database before and after the run was close enough to call this a success.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Deploy this change to Production.
