### PR TITLE
Do not pause commander when executing `cyhy-archive`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.1.0",
+    version="1.1.1",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),

--- a/var/cyhy_archive.sh
+++ b/var/cyhy_archive.sh
@@ -20,7 +20,7 @@ S3_BUCKET_REGION=$3
 
 # Run cyhy-archive script
 echo "Starting cyhy-archive script, creating archives in ${ARCHIVE_DIR}..."
-/usr/local/bin/cyhy-archive ${ARCHIVE_DIR}
+/usr/local/bin/cyhy-archive --no-commander-pause ${ARCHIVE_DIR}
 
 RESULT=$?
 if [ $RESULT -ne 0 ]; then


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `--no-commander-pause` option when calling the `cyhy-archive` script in `cyhy_archive.sh` (invoked by the [weekly cron job](https://github.com/cisagov/cyhy_amis/blob/98cb3b43d0bbc348d982b8475a1836c02d29531b/ansible/roles/cyhy_archive/tasks/main.yml#L12-L26)).  That flag means that `cyhy-archive` does not attempt to pause the CyHy commander before it executes the archive process.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I recently noticed that the `cyhy-archive` script was waiting for the commander to pause and it reached our 30-minute limit (on the pause; because our commander cycles now often take longer than 30 minutes), then proceeded with the archive process without the commander being paused.  The archive process still completed successfully, even though the commander was running normally at the same time.

Since there is no clear benefit to pausing the commander while `cyhy-archive` does its thing, we might as well skip the pausing.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Visual inspection.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
- [x] Deploy this change to Production (in this case, it will be done manually)
