### PR TITLE
Add `latest_time` index to `VulnScanDoc`

### DIFF
--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -772,6 +772,7 @@ class VulnScanDoc(ScanDoc):
                 False,
                 False,
             ),
+            ("latest_time", [("latest", 1), ("time", 1)], False, False),
         )
 
     def save(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.1.1",
+    version="1.1.2",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a `latest_time` index to the `VulnScanDoc` class.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

A recent review of `cyhy-archive` performance shows the following metrics:
* `HostScanDoc`
    * ~63.8M documents before archive
    * Exporting ~987k documents took 21 seconds
    * Deleting ~987k documents took ~1.5 minutes
* `PortScanDoc`
    * ~2.2B documents before archive
    * Exporting ~154M documents took ~2.7 hours
    * Deleting ~154M documents took ~3 hours
* `VulnScanDoc`
    * ~121M documents before archive
    * Exporting ~1.5M documents took ~4 hours
    * Deleting ~1.5M documents took ~3.5 hours

I am hopeful that adding this index to `VulnScanDoc` will bring `cyhy-archive` performance for that collection more in line with what we are seeing for `PortScanDoc`, which has a similar index already.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Visual inspection.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
- [x] Deploy this change to Production (manually in this case).
- [x] Create index; run (in a screen session on Production database instance) `cyhy-tool ensure-indices` (run in background to minimize disturbance to Prod DB)
