### PR TITLE
Make `cyhy-archive` document count mismatch a warning instead of an error

### DIFF
--- a/bin/cyhy-archive
+++ b/bin/cyhy-archive
@@ -263,7 +263,7 @@ def archive_and_delete(db, curr_date, archive_dir, parsed_db_uri):
 
 def main():
     start_time = util.utcnow()
-    args = docopt(__doc__, version="v0.0.1")
+    args = docopt(__doc__, version="v1.0.0")
     logging_setup(args["--debug"])
     logger.info("cyhy-archive started")
     db = database.db_from_config(args["--section"])

--- a/bin/cyhy-archive
+++ b/bin/cyhy-archive
@@ -215,19 +215,23 @@ def archive_and_delete(db, curr_date, archive_dir, parsed_db_uri):
             delete_success = delete_output.get("ok")
             results["deleted_counts"][collection_name] = delete_output.get("n")
 
-            # check that number of deleted documents matches the number of exported/archived documents
+            # Compare the number of deleted documents to the number of
+            # exported/archived documents and log a warning if they don't match.
+            # The counts should match when the commander has been paused, but if
+            # the commander is still running, it is possible that documents had
+            # their "latest" flag set to False after the export but before the
+            # delete.
             if (
                 results["deleted_counts"][collection_name]
                 != results["exported_counts"][collection_name]
             ):
-                logger.error(
+                logger.warning(
                     "{}: count of exported documents ({:,}) does not match count of deleted documents ({:,})".format(
                         collection_name,
                         results["exported_counts"][collection_name],
                         results["deleted_counts"][collection_name],
                     )
                 )
-                return results
             results["delete_success"] = True
             logger.info(
                 "{}: {:,} documents successfully deleted".format(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.1.3",
+    version="1.1.4",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies `cyhy-archive` so that if there is a difference in the number of exported and deleted records from a collection, a warning is logged instead of an error and the script continues on.  Previously, the script would exit after the "document count mismatch" error was logged.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change allows for the mismatch in document counts.  In our case, it is unavoidable now that we are no longer pausing the commander before running `cyhy-archive`.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this in the most realistic way possible- by running it in production, just like they taught us in school (not!)

In this case, it was fairly low-risk and the test was successful:

```console
2025-09-24 20:04:23,844 INFO cyhy-archive - cyhy-archive started
2025-09-24 20:04:23,853 INFO cyhy-archive - ============================================================
2025-09-24 20:04:23,853 INFO cyhy-archive - Database to be archived: database1.cyhy:27017/cyhy
2025-09-24 20:04:23,853 INFO cyhy-archive - Directory to archive to: /var/lib/mongodb/cyhy_archives
2025-09-24 20:04:23,853 INFO cyhy-archive - Data to be archived:
2025-09-24 20:04:23,853 INFO cyhy-archive -   host_scans older than 548 days
2025-09-24 20:04:23,853 INFO cyhy-archive -   port_scans older than 90 days
2025-09-24 20:04:23,854 INFO cyhy-archive -   vuln_scans older than 548 days
2025-09-24 20:04:23,854 INFO cyhy-archive - ============================================================
2025-09-24 20:04:23,854 INFO cyhy-archive - host_scans: 62,907,482 documents exist before archiving
2025-09-24 20:04:24,006 INFO cyhy-archive - host_scans: exporting documents older than 2024-03-25T20:04:23.844029Z to /var/lib/mongodb/cyhy_archives/cyhy_archive_host_scans_20250924.gz
2025-09-24 20:04:41,370 INFO cyhy-archive - host_scans: 754,477 documents successfully exported
2025-09-24 20:08:02,326 INFO cyhy-archive - host_scans: 754,477 documents successfully deleted
2025-09-24 20:08:02,327 INFO cyhy-archive - host_scans: 62,153,005 documents exist after archiving
2025-09-24 20:08:02,327 INFO cyhy-archive - port_scans: 2,162,134,551 documents exist before archiving
2025-09-24 20:08:02,334 INFO cyhy-archive - port_scans: exporting documents older than 2025-06-26T20:04:23.844029Z to /var/lib/mongodb/cyhy_archives/cyhy_archive_port_scans_20250924.gz
2025-09-24 23:22:17,741 INFO cyhy-archive - port_scans: 97,988,296 documents successfully exported
tail: /var/log/cyhy/archive.log: file truncated
2025-09-25 03:04:38,022 WARNING cyhy-archive - port_scans: count of exported documents (97,988,296) does not match count of deleted documents (98,005,833)
2025-09-25 03:04:38,022 INFO cyhy-archive - port_scans: 98,005,833 documents successfully deleted
2025-09-25 03:04:38,023 INFO cyhy-archive - port_scans: 2,068,346,053 documents exist after archiving
2025-09-25 03:04:38,023 INFO cyhy-archive - vuln_scans: 122,003,295 documents exist before archiving
2025-09-25 03:04:38,041 INFO cyhy-archive - vuln_scans: exporting documents older than 2024-03-25T20:04:23.844029Z to /var/lib/mongodb/cyhy_archives/cyhy_archive_vuln_scans_20250924.gz
2025-09-25 03:10:20,268 INFO cyhy-archive - vuln_scans: 2,439,752 documents successfully exported
2025-09-25 03:13:06,371 INFO cyhy-archive - vuln_scans: 2,439,752 documents successfully deleted
2025-09-25 03:13:06,371 INFO cyhy-archive - vuln_scans: 119,563,543 documents exist after archiving
2025-09-25 03:13:06,371 INFO cyhy-archive - cyhy-archive successfully completed in 25,722.528 seconds (428.7 minutes)
```

Note that the mismatch message is now logged as a `WARNING` and that the entire process completed successfully.

Also note that the changes in #108 **helped a ton.**  We exported and deleted ~2.4M `vuln_scans` documents in **less than 9 minutes**.  A recent run in production (before the DB index was added in #108) took **~7.5 hours** for ~1.5M documents.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
