### PR TITLE
Display hostnames in cyhy-ticket

### DIFF
--- a/bin/cyhy-ticket
+++ b/bin/cyhy-ticket
@@ -93,7 +93,6 @@ def print_ticket_details(tickets):
         t.pop("open_flag_str")
         t.pop("fp_flag_str")
         t.pop("severity_str")
-        t.pop("hostname")
 
 
 def list_false_positive(db, cidrs):

--- a/bin/cyhy-ticket
+++ b/bin/cyhy-ticket
@@ -246,7 +246,7 @@ def set_false_positive(db, cidrs):
 
 
 def main():
-    args = docopt(__doc__, version="v0.0.1")
+    args = docopt(__doc__, version="v1.0.0")
     db = database.db_from_config(args["--section"])
 
     nets = parse_addresses(args["ADDRESSES"])

--- a/bin/cyhy-ticket
+++ b/bin/cyhy-ticket
@@ -56,7 +56,7 @@ def read_file(filename):
 
 
 def print_ticket_details(tickets):
-    print "{:<26}{:<7}{:<7}{:<19}{:<10}{:<14}{:<15}{:<7}{:<10}{:}".format(
+    print "{:<26}{:<7}{:<7}{:<19}{:<10}{:<14}{:<15}{:<7}{:<10}{:<50}{:}".format(
         "Ticket ID",
         "Open?",
         "FP?",
@@ -66,6 +66,7 @@ def print_ticket_details(tickets):
         "FP Expiration",
         "Port",
         "Protocol",
+        "Hostname",
         "Vulnerability Name",
     )
 
@@ -73,14 +74,15 @@ def print_ticket_details(tickets):
         t["open_flag_str"] = str(t["open"])
         t["fp_flag_str"] = str(t["false_positive"])
         t["severity_str"] = SEVERITY_LEVELS[t["details"]["severity"]]
+        t["hostname"] = t.get("hostname", "")
         if t["false_positive"]:
             t["fp_effective_date"], t["fp_expiration_date"] = t.false_positive_dates
-            print "{_id:<26}{open_flag_str:<7}{fp_flag_str:<7}{time_opened:%Y-%m-%d %H:%M}   {severity_str:<10}{fp_effective_date:%Y-%m-%d}    {fp_expiration_date:%Y-%m-%d}     {port:<7}{protocol:<10}{details[name]}".format(
+            print "{_id:<26}{open_flag_str:<7}{fp_flag_str:<7}{time_opened:%Y-%m-%d %H:%M}   {severity_str:<10}{fp_effective_date:%Y-%m-%d}    {fp_expiration_date:%Y-%m-%d}     {port:<7}{protocol:<10}{hostname:<48}  {details[name]}".format(
                 **t
             )
         else:
             t["fp_effective_date"], t["fp_expiration_date"] = None, None
-            print "{_id:<26}{open_flag_str:<7}{fp_flag_str:<7}{time_opened:%Y-%m-%d %H:%M}   {severity_str:<39}{port:<7}{protocol:<10}{details[name]}".format(
+            print "{_id:<26}{open_flag_str:<7}{fp_flag_str:<7}{time_opened:%Y-%m-%d %H:%M}   {severity_str:<39}{port:<7}{protocol:<10}{hostname:<48}  {details[name]}".format(
                 **t
             )
 
@@ -91,6 +93,7 @@ def print_ticket_details(tickets):
         t.pop("open_flag_str")
         t.pop("fp_flag_str")
         t.pop("severity_str")
+        t.pop("hostname")
 
 
 def list_false_positive(db, cidrs):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.1.4",
+    version="1.1.5",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the `cyhy-ticket` script to output the hostname (if present) associated with each ticket.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Now that tickets can have hostnames (as of #101), that information should be visible in all of our supporting tools.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I ran `cyhy-ticket` against some test IP addresses that have tickets with hostnames and some that do not.  In both cases, the script worked as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
