### PR TITLE
Update the Docker image helper script

### DIFF
--- a/generate_cyhy_docker_image.sh
+++ b/generate_cyhy_docker_image.sh
@@ -30,13 +30,10 @@ function usage {
 # requirements and then exit.
 function check_dependencies {
   required_tools="docker"
-  for tool in $required_tools
-  do
-    if [ -z "$(command -v "$tool")" ]
-    then
+  for tool in $required_tools; do
+    if [ -z "$(command -v "$tool")" ]; then
       echo "This script requires the following tools to run:"
-      for item in $required_tools
-      do
+      for item in $required_tools; do
         echo "- $item"
       done
       exit 1
@@ -44,33 +41,29 @@ function check_dependencies {
   done
 }
 
-while (( "$#" ))
-do
+while (("$#")); do
   case "$1" in
-    -h|--help)
+    -h | --help)
       usage 0
       ;;
-    -k|--maxmind-key)
-      if [ -n "$2" ] && [ "${2:0:1}" != "-" ]
-      then
+    -k | --maxmind-key)
+      if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
         MAXMIND_LICENSE_KEY=$2
         shift 2
       else
         usage 1
       fi
       ;;
-    -n|--image-name)
-      if [ -n "$2" ] && [ "${2:0:1}" != "-" ]
-      then
+    -n | --image-name)
+      if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
         IMAGE_NAME=$2
         shift 2
       else
         usage 1
       fi
       ;;
-    -t|--image-tag)
-      if [ -n "$2" ] && [ "${2:0:1}" != "-" ]
-      then
+    -t | --image-tag)
+      if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
         IMAGE_TAG=$2
         shift 2
       else
@@ -87,12 +80,11 @@ check_dependencies
 
 BASE_IMAGE_NAME="$(echo "$IMAGE_NAME" | tr "/" "_")_$IMAGE_TAG"
 IMAGE_OUTPUT_FILE="${BASE_IMAGE_NAME}_$(date +'%Y%m%d').tgz"
-if [ -z ${MAXMIND_LICENSE_KEY} ]
-then
+if [ -z ${MAXMIND_LICENSE_KEY} ]; then
   MAXMIND_LICENSE_KEY=$(aws ssm get-parameter \
-      --output text \
-      --name "/cyhy/core/geoip/license_key" \
-      --with-decryption \
+    --output text \
+    --name "/cyhy/core/geoip/license_key" \
+    --with-decryption \
     | awk -F"\t" '{print $6}')
 fi
 

--- a/generate_cyhy_docker_image.sh
+++ b/generate_cyhy_docker_image.sh
@@ -80,7 +80,7 @@ check_dependencies
 
 BASE_IMAGE_NAME="$(echo "$IMAGE_NAME" | tr "/" "_")_$IMAGE_TAG"
 IMAGE_OUTPUT_FILE="${BASE_IMAGE_NAME}_$(date +'%Y%m%d').tgz"
-if [ -z ${MAXMIND_LICENSE_KEY} ]; then
+if [ -z "${MAXMIND_LICENSE_KEY}" ]; then
   MAXMIND_LICENSE_KEY=$(aws ssm get-parameter \
     --output text \
     --name "/cyhy/core/geoip/license_key" \

--- a/generate_cyhy_docker_image.sh
+++ b/generate_cyhy_docker_image.sh
@@ -6,6 +6,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+MAXMIND_LICENSE_KEY=""
 IMAGE_NAME="cisagov/cyhy-core"
 IMAGE_TAG="latest"
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request reformats the `generate_cyhy_docker_image.sh` helper script, fixes a shellcheck error in the script, and lastly fixes an unbound variable error in the script.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I tried to build a local `cisagov/cyhy-core` Docker image using the default behavior, but received an unbound variable error instead of a successful image build. Since I was going to fix that bug I decided to ensure the script is formatted with out current `shfmt` rules and that it otherwise passes `shellcheck` testing.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that I could successfully build a `cisagov/cyhy-core` Docker image with the updated script.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
