### PR TITLE
Add an additional TicketDoc index

### DIFF
--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -508,6 +508,18 @@ class TicketDoc(RootDoc):
                 False,
                 True,
             ),
+            (
+                "owner_source_false_positive_severity_time_closed",
+                [
+                    ("owner", 1),
+                    ("source", 1),
+                    ("false_positive", 1),
+                    ("details.severity", 1),
+                    ("time_closed", 1),
+                ],
+                False,
+                True,
+            ),
         )
 
     def save(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.1.7",
+    version="1.1.8",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds one new index to the tickets collection.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

During report generation, a query with these fields was observed to be taking a very long time (450+ seconds).  This new index should speed things up substantially.

This is the query that was observed to be very slow:
* https://github.com/cisagov/cyhy-reports/blob/34d26478c2c41ef781fd9220cc29bb9b8212ef87/cyhy_report/customer/generate_report.py#L515-L525


<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This new index was added in Production during a reporting cycle and the performance improvement was drastic.  Before the index was added, reports were taking ~900 seconds to generate.  After the index was created, reports were taking 30-60 seconds to generate.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
- [x] Deploy this code to Production.
- [x] Update indices in Production: `cyhy-tool ensure-indices` (note no `--foreground` option; we want to run this in the background so that it will not block the commander from doing its thing)
