### PR TITLE
Improve DNS error handling and logging in `cyhy-domainsync`

### DIFF
--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -83,7 +83,14 @@ def close_tickets(db, ip, hostname, reason):
     return result["nModified"]
 
 def main():
-    args = docopt(__doc__, version="v1.0.1")
+
+    # Dictionary to track certain DNS exceptions encountered during processing
+    dns_exceptions = {
+        "DNSException": [],
+        "NoNameservers": [],
+        "Timeout": [],
+    }
+
     try:
         db = database.db_from_config(args["--section"], args["--config-file"])
 
@@ -111,7 +118,36 @@ def main():
 
                 print("  " + str(hostdocs.count()) + " HostDocs currently reference this hostname")
 
-                ip_set = get_ipv4_addresses(hostname)
+                try:
+                    ip_set = get_ipv4_addresses(hostname)
+                # Note that the following DNS exceptions do not trigger any
+                # changes to HostDocs or TicketDocs, as opposed to those handled
+                # within get_ipv4_addresses().  This is because these exceptions
+                # likely indicate a temporary DNS issue or misconfiguration, and
+                # we don't want to make any HostDoc or TicketDoc changes based
+                # on incomplete or invalid DNS results.
+                except resolver.NoNameservers as e:
+                    print("    Warning: No nameservers available to resolve " + hostname)
+                    print(str(e))
+                    dns_exceptions["NoNameservers"].append(
+                        {"hostname": hostname, "owner": r["_id"]}
+                    )
+                    continue  # Skip to the next hostname
+                except resolver.Timeout as e:
+                    print("    Warning: DNS query timed out for " + hostname)
+                    print(str(e))
+                    dns_exceptions["Timeout"].append(
+                        {"hostname": hostname, "owner": r["_id"]}
+                    )
+                    continue  # Skip to the next hostname
+                except exception.DNSException as e:
+                    print("    Warning: Unexpected DNS exception for " + hostname)
+                    print(str(e))
+                    dns_exceptions["DNSException"].append(
+                        {"hostname": hostname, "owner": r["_id"]}
+                    )
+                    continue  # Skip to the next hostname
+
                 print("  " + str(len(ip_set)) + " IPv4 addresses found for this hostname")
                 for ip in ip_set:
                     print("    " + str(ip)),

--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -50,8 +50,9 @@ def get_ipv4_addresses(hostname):
     except resolver.NoAnswer:
         print("    Warning: DNS NoAnswer (no A records found) for " + hostname)
         return set()
-    except resolver.NXDOMAIN:
+    except resolver.NXDOMAIN as e:
         print("    Warning: DNS NXDOMAIN (no domain exists) for " + hostname)
+        print("    " + str(e))
         return set()
     except resolver.YXDOMAIN:
         print("    Warning: DNS YXDOMAIN (query name too long after DNAME substitution) for " + hostname)

--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -83,6 +83,7 @@ def close_tickets(db, ip, hostname, reason):
     return result["nModified"]
 
 def main():
+    args = docopt(__doc__, version="v1.0.2")
 
     # Dictionary to track certain DNS exceptions encountered during processing
     dns_exceptions = {

--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -227,6 +227,11 @@ def main():
         tally_doc.sync(db)
         print("Synchronized " + default_owner + " TallyDoc")
 
+        print("\nDNS exceptions encountered during processing:")
+        for exception_type, entries in dns_exceptions.items():
+            print("  %s: %d occurrences" % (exception_type, len(entries)))
+            for entry in entries:
+                print("    %s (%s)" % (entry["hostname"], entry["owner"]))
 
     except:
         logging.exception("Unexpected exception")

--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -97,16 +97,16 @@ def main():
         for r in get_requests(db):
             print(r["_id"])
             for hostname in r.get("hostnames", []):
-                print("\t" + hostname),
+                print("  " + hostname),
                 # Find all the HostDocs that have this domain name as a value in their hostnames dictionary
                 hostdocs = db.HostDoc.get_by_hostname(hostname)
 
-                print("\t" + str(hostdocs.count()) + " HostDocs currently reference this hostname")
+                print("  " + str(hostdocs.count()) + " HostDocs currently reference this hostname")
 
                 ip_set = get_ipv4_addresses(hostname)
-                print("\t" + str(len(ip_set)) + " IPv4 addresses found for this hostname")
+                print("  " + str(len(ip_set)) + " IPv4 addresses found for this hostname")
                 for ip in ip_set:
-                    print("\t\t" + str(ip)),
+                    print("    " + str(ip)),
                     # Lookup the HostDoc for this IP address
                     host_doc = db.HostDoc.get_by_ip(ip)
 
@@ -140,7 +140,7 @@ def main():
                     for h in host_doc["hostnames"]:
                         if h["hostname"] == hostname:
                             if h["owner"] != r["_id"]:
-                                print("\t\tHostname owner updated in HostDoc (%s -> %s)" % (h["owner"], r["_id"]))
+                                print("    Hostname owner updated in HostDoc (%s -> %s)" % (h["owner"], r["_id"]))
                                 h["owner"] = r["_id"]
                             break
                     else:
@@ -154,13 +154,13 @@ def main():
                 for host in hostdocs:
                     # If the hostdoc ip is not in the ip_set, remove the domain from the list of owners
                     if host.ip not in ip_set:
-                        print("\tRemoving " + hostname + " from " + str(host.ip))
+                        print("  Removing " + hostname + " from " + str(host.ip))
                         host["hostnames"] = [i for i in host["hostnames"] if i["hostname"] != hostname]
                         host.save()
  
                         # Close all open tickets with this ip and hostname
                         closed_count = close_tickets(db, host.ip, hostname, "Hostname no longer resolves to this IP address")
-                        print("\t%d tickets documents closed for %s[%s]" % (
+                        print("  %d tickets documents closed for %s[%s]" % (
                             closed_count,
                             host.ip,
                             hostname

--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -43,10 +43,18 @@ def get_ipv4_addresses(hostname):
         answers = resolver.query(hostname, 'A')
         ip_list = [IPAddress(answer.address) for answer in answers]
         return set(ip_list)
-    except exception.DNSException as e:
-        # Could not resolve domain name
-        return set()
+    # Could not resolve domain name
     except AddrFormatError:
+        print("    Warning: Address format error for " + hostname)
+        return set()
+    except resolver.NoAnswer:
+        print("    Warning: DNS NoAnswer (no A records found) for " + hostname)
+        return set()
+    except resolver.NXDOMAIN:
+        print("    Warning: DNS NXDOMAIN (no domain exists) for " + hostname)
+        return set()
+    except resolver.YXDOMAIN:
+        print("    Warning: DNS YXDOMAIN (query name too long after DNAME substitution) for " + hostname)
         return set()
 
 def close_tickets(db, ip, hostname, reason):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.1.8",
+    version="1.1.9",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR improves the DNS error handling and logging in `cyhy-domainsync` by catching and logging the following exceptions:
* `resolver.NoAnswer` (no A records found)
* `resolver.NXDOMAIN` (no domain exists)
* `resolver.YXDOMAIN` (query name too long after DNAME substitution)
* `resolver.NoNameservers` (no nameservers available)
* `resolver.Timeout` (DNS query timeout)

The script now also outputs a summary of counts for certain exceptions at the end:
```
DNS exceptions encountered during processing:
  NoNameservers: 0 occurrences
  DNSException: 0 occurrences
  Timeout: 0 occurrences
```


<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

@jsf9k and I discussed the possibility of AWS throttling our DNS queries ([AWS has a 1,024 packet per second limit for DNS requests to the VPC DNS resolver](https://docs.aws.amazon.com/vpc/latest/userguide/AmazonDNS-concepts.html#vpc-dns-limits)) as the number of hostnames in CyHy increases, so we wanted to improve our logging of DNS exceptions to help us identify any DNS issues as we grow.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I ran this script and confirmed that logging worked as intended for `resolver.NoAnswer`, which is easily triggered.  I did not test the remaining exceptions, though I did confirm that the summary at the end is printing as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
- [x] Deploy to Production.
