### PR TITLE
Add a workflow to automatically `black`en on pull requests

### DIFF
--- a/.github/workflows/blacken.yml
+++ b/.github/workflows/blacken.yml
@@ -1,0 +1,96 @@
+---
+name: Blacken repository
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+
+# Set a default shell for any run steps. The `-Eueo pipefail` sets errtrace,
+# nounset, errexit, and pipefail. The `-x` will print all commands as they are
+# run. Please see the GitHub Actions documentation for more information:
+# https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs
+defaults:
+  run:
+    shell: bash -Eueo pipefail -x {0}
+
+jobs:
+  diagnostics:
+    name: Run diagnostics
+    # This job does not need any permissions
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      # Note that a duplicate of this step must be added at the top of
+      # each job.
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          check_github_status: "true"
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          output_workflow_context: "true"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+  blacken:
+    needs:
+      - diagnostics
+    permissions:
+      # stefanzweifel/git-auto-commit-action needs this to commit changes
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - uses: actions/checkout@v5
+        with:
+          # Needed by stefanzweifel/git-auto-commit-action to support the pull_request
+          # trigger.
+          ref: ${{ github.head_ref }}
+      - name: Blacken project
+        uses: cisagov/action-blacken-python2@v1
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: Format project with `black`

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -12,9 +12,9 @@ GEODB_FILE_PATHS = []
 
 # The list of restricted countries was provided by CISA International Affairs
 # in March 2024.
-# The MaxMind GeoLite2 and GeoIP2 databases that we support use 
+# The MaxMind GeoLite2 and GeoIP2 databases that we support use
 # https://www.geonames.org/countries/ as the data source for country names.
-# For more info, see: 
+# For more info, see:
 # https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRNFD5Z5EWNCAXM6SZZ5H2C
 RESTRICTED_COUNTRIES = [
     "Afghanistan",
@@ -78,6 +78,6 @@ class GeoLocDB(object):
             if response.country.name in RESTRICTED_COUNTRIES:
                 return response.country.name
         except AddressNotFoundError:
-            print >> sys.stderr, "IP %s not found in geolocation database" % ip
+            print >>sys.stderr, "IP %s not found in geolocation database" % ip
 
         return ""

--- a/cyhy/db/chdatabase.py
+++ b/cyhy/db/chdatabase.py
@@ -42,8 +42,8 @@ class CHDatabase(object):
 
     def __init__(self, db, state_manager=None, scheduler=None, next_scan_limit=2000):
         """db: MongoDB instance
-           state_manager: class that implements a HostStateManager
-           scheduler: class that implements a Scheduler"""
+        state_manager: class that implements a HostStateManager
+        scheduler: class that implements a Scheduler"""
         self.__db = db
         self.__logger = logging.getLogger(__name__)
         self.__scheduler = scheduler
@@ -183,9 +183,9 @@ class CHDatabase(object):
         self, ip, up=None, reason=None, has_open_ports=None, was_failure=False
     ):
         """Attempts to move host from one state to another.
-           returns (HostDoc, state_changed)
-            - HostDoc: host that was transitioned
-            - state_changed: True if the state changed, False otherwise."""
+        returns (HostDoc, state_changed)
+         - HostDoc: host that was transitioned
+         - state_changed: True if the state changed, False otherwise."""
         host = self.__db.HostDoc.get_by_ip(ip)
         if host == None:
             self.__logger.warning(
@@ -470,8 +470,8 @@ class CHDatabase(object):
         def add_networks_and_hostnames_to_snapshot(request_doc, snapshot_doc):
             """Adds networks and hostnames from a request doc to a snapshot doc
 
-               If the request document has hostnames, it also adds the IP
-               addresses of those hostnames to the snapshot."""
+            If the request document has hostnames, it also adds the IP
+            addresses of those hostnames to the snapshot."""
             if request_doc:
                 snapshot_doc["networks"] |= request_doc.networks
                 # Since snapshot documents are initialized with their hostnames
@@ -481,7 +481,9 @@ class CHDatabase(object):
                 # If the request doc has hostnames, add the IP addresses of
                 # those hostnames to the snapshot.
                 if request_doc.get("hostnames"):
-                    for host in self.__db.HostDoc.get_hosts_with_hostnames(request_doc["hostnames"]):
+                    for host in self.__db.HostDoc.get_hosts_with_hostnames(
+                        request_doc["hostnames"]
+                    ):
                         snapshot_doc["networks"].add(host.ip)
 
         owner_doc = self.__db.RequestDoc.get_by_owner(owner)

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -106,7 +106,7 @@ def combine_results(d, results, envelope=None):
 
 def run_pipeline((pipeline, collection), db):
     """Run an aggregation using a pipeline, collection tuple like those provided
-       in the queries module."""
+    in the queries module."""
     try:
         results = db[collection].aggregate(pipeline, allowDiskUse=True)
     except OperationFailure, e:
@@ -120,7 +120,7 @@ def run_pipeline((pipeline, collection), db):
 
 def run_pipeline_cursor((pipeline, collection), db):
     """Like run_pipeline but uses a cursor to access results larger than the max
-       MongoDB size."""
+    MongoDB size."""
     cursor = db[collection].aggregate(pipeline, allowDiskUse=True, cursor={})
     results = []
     for doc in cursor:
@@ -474,11 +474,7 @@ class TicketDoc(RootDoc):
             ),
             (
                 "ip_hostname_open",
-                [
-                    ("ip_int", 1),
-                    ("hostname", 1),
-                    ("open", 1)
-                ],
+                [("ip_int", 1), ("hostname", 1), ("open", 1)],
                 False,
                 True,
             ),
@@ -960,7 +956,9 @@ class HostDoc(RootDoc):
     def get_hosts_with_hostnames(self, hostnames):
         # Return HostDocs whose list of hostnames contains any of the given list
         # of hostnames
-        return self.find({"hostnames": {"$elemMatch": {"hostname": {"$in": hostnames}}}})
+        return self.find(
+            {"hostnames": {"$elemMatch": {"hostname": {"$in": hostnames}}}}
+        )
 
     def get_by_ip(self, ip):
         int_ip = int(ip)
@@ -1046,7 +1044,7 @@ class HostDoc(RootDoc):
 
     def reset_state_by_owner(self, owner, init_stage, jump_start=False):
         """Moves hosts back to initial stage and resets status for a single-scan.
-           jump_start allows previously up hosts to skip the NETSCANx stages."""
+        jump_start allows previously up hosts to skip the NETSCANx stages."""
         now = util.utcnow()
         if jump_start:
             self.collection.update(
@@ -1130,7 +1128,9 @@ class RequestDoc(RootDoc):
     __collection__ = REQUEST_COLLECTION
     # This regex was taken from the Python example at
     # https://emailregex.com/
-    __EmailAddressRegex = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)")
+    __EmailAddressRegex = re.compile(
+        r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
+    )
     structure = {
         "agency": {
             "acronym": basestring,
@@ -1365,7 +1365,7 @@ class RequestDoc(RootDoc):
         self, as_lists=False, stakeholders_only=False, include_retired=False
     ):
         """returns a dict of types to owners.  The owners can be in a set or list depending on "as_lists" parameter.
-           "stakeholders_only" parameter eliminates non-stakeholders from the dict."""
+        "stakeholders_only" parameter eliminates non-stakeholders from the dict."""
         types = defaultdict(lambda: set())
 
         # No need to reinvent the wheel here- call get_owner_to_type_dict()
@@ -1691,7 +1691,7 @@ class CVEDoc(RootDoc):
         "_id": basestring,  # CVE string
         "cvss_score": float,
         "cvss_version": basestring,
-        "severity": int
+        "severity": int,
     }
     required_fields = ["_id", "cvss_score", "cvss_version", "severity"]
     default_values = {}

--- a/cyhy/db/host_state_manager.py
+++ b/cyhy/db/host_state_manager.py
@@ -12,7 +12,7 @@ class DefaultHostStateManager(object):
 
     def transition(self, host_doc, up=None, has_open_ports=None, was_failure=False):
         """applies a transition of state to a HostDoc.
-           returns: True if there was a change, False otherwise.
+        returns: True if there was a change, False otherwise.
         """
         new_stage, new_status, was_changed, finished_stage = self.new_state(
             host_doc, up, has_open_ports, was_failure
@@ -26,7 +26,7 @@ class DefaultHostStateManager(object):
 
     def new_state(self, host_doc, up=None, has_open_ports=None, was_failure=False):
         """calculates the new state for a host.
-           returns: stage, status, was_changed, finished_stage
+        returns: stage, status, was_changed, finished_stage
         """
         stage = host_doc["stage"]
         status = host_doc["status"]

--- a/cyhy/db/queries.py
+++ b/cyhy/db/queries.py
@@ -8,13 +8,15 @@ import database
 def addresses_scanned_pl(owners):
     return (
         [
-            {"$match": {
-                "$or": [
-                    {"owner": {"$in": owners}},
-                    {"hostnames": {"$elemMatch": {"owner": {"$in": owners}}}}
-                ],
-                "latest_scan.DONE": {"$ne": None}
-            }},
+            {
+                "$match": {
+                    "$or": [
+                        {"owner": {"$in": owners}},
+                        {"hostnames": {"$elemMatch": {"owner": {"$in": owners}}}},
+                    ],
+                    "latest_scan.DONE": {"$ne": None},
+                }
+            },
             {"$group": {"_id": {}, "addresses_scanned": {"$sum": 1}}},
         ],
         database.HOST_COLLECTION,
@@ -24,13 +26,15 @@ def addresses_scanned_pl(owners):
 def host_count_pl(owners):
     return (
         [
-            {"$match": {
-                "$or": [
-                    {"owner": {"$in": owners}},
-                    {"hostnames": {"$elemMatch": {"owner": {"$in": owners}}}}
-                ],
-                "state.up": True
-            }},
+            {
+                "$match": {
+                    "$or": [
+                        {"owner": {"$in": owners}},
+                        {"hostnames": {"$elemMatch": {"owner": {"$in": owners}}}},
+                    ],
+                    "state.up": True,
+                }
+            },
             {"$group": {"_id": {}, "host_count": {"$sum": 1}}},
         ],
         database.HOST_COLLECTION,
@@ -234,11 +238,14 @@ def time_span(snapshot_oid):
 def host_time_span(owners):
     return (
         [
-            {"$match": {"$or":
-                [
-                    {"owner": {"$in": owners}},
-                    {"hostnames": {"$elemMatch": {"owner": {"$in": owners}}}}
-                ]}},
+            {
+                "$match": {
+                    "$or": [
+                        {"owner": {"$in": owners}},
+                        {"hostnames": {"$elemMatch": {"owner": {"$in": owners}}}},
+                    ]
+                }
+            },
             {
                 "$group": {
                     "_id": {},

--- a/cyhy/test/test_host_state_manager.py
+++ b/cyhy/test/test_host_state_manager.py
@@ -110,7 +110,9 @@ class TestStateManager:
     ):
         h["stage"] = i_stage
         h["status"] = STATUS.RUNNING
-        was_changed, finished_stage = state_manager.transition(h, has_open_ports=has_open_ports)
+        was_changed, finished_stage = state_manager.transition(
+            h, has_open_ports=has_open_ports
+        )
         assert was_changed == True, '"was_changed" should be True'
         assert finished_stage == True, '"finished_stage" should be True'
         assert h["stage"] == f_stage, "stage should be %s" % f_stage

--- a/cyhy/test/test_ticket_manager.py
+++ b/cyhy/test/test_ticket_manager.py
@@ -178,6 +178,7 @@ VULN_6 = {
     "latest": True,
 }
 
+
 @pytest.fixture
 def vuln_ticket_manager1(database):
     vtm = VulnTicketManager(database, SOURCE_NESSUS)
@@ -288,6 +289,7 @@ def database_w_hostname_vulns(database):
     vtm.open_ticket(VULN_5, "test vuln detected")
     vtm.open_ticket(VULN_6, "test vuln detected")
     return database
+
 
 class TestVulnTickets:
     def test_clear_tickets(self, database):
@@ -758,50 +760,102 @@ class TestVulnsWithHostnames:
     """See https://github.com/cisagov/cyhy-system/issues/70"""
 
     def test_tickets_with_hostname(self, database_w_hostname_vulns):
-        assert database_w_hostname_vulns.tickets.count() == 3, "collection should have 3 tickets"
-        assert database_w_hostname_vulns.tickets.find({"open": True, "hostname": "foo.gov"}).count() == 1, "collection should have 1 open ticket with hostname foo.gov"
-        assert database_w_hostname_vulns.tickets.find({"open": True, "hostname": "bar.gov"}).count() == 1, "collection should have 1 open ticket with hostname bar.gov"
-    
+        assert (
+            database_w_hostname_vulns.tickets.count() == 3
+        ), "collection should have 3 tickets"
+        assert (
+            database_w_hostname_vulns.tickets.find(
+                {"open": True, "hostname": "foo.gov"}
+            ).count()
+            == 1
+        ), "collection should have 1 open ticket with hostname foo.gov"
+        assert (
+            database_w_hostname_vulns.tickets.find(
+                {"open": True, "hostname": "bar.gov"}
+            ).count()
+            == 1
+        ), "collection should have 1 open ticket with hostname bar.gov"
+
     def test_close_reopen_verify_tickets(self, database_w_hostname_vulns):
-        assert database_w_hostname_vulns.tickets.find({"open": True}).count() == 3, "collection should have 3 open tickets"
+        assert (
+            database_w_hostname_vulns.tickets.find({"open": True}).count() == 3
+        ), "collection should have 3 open tickets"
         vtm = VulnTicketManager(database_w_hostname_vulns, SOURCE_NESSUS)
         vtm.ips = IPSet([IPS[0]])
         vtm.ports = PORTS
         vtm.source_ids = SOURCE_IDS
         vtm.close_tickets()
-        assert database_w_hostname_vulns.tickets.find({"open": True}).count() == 0, "collection should have 0 open tickets"
+        assert (
+            database_w_hostname_vulns.tickets.find({"open": True}).count() == 0
+        ), "collection should have 0 open tickets"
 
         vtm.open_ticket(VULN_5, "test vuln re-detected")
-        assert database_w_hostname_vulns.tickets.find({"open": True, "hostname": "foo.gov"}).count() == 1, "collection should have 1 open ticket with hostname foo.gov"
-        ticket = database_w_hostname_vulns.tickets.find_one({"open": True, "hostname": "foo.gov"})
+        assert (
+            database_w_hostname_vulns.tickets.find(
+                {"open": True, "hostname": "foo.gov"}
+            ).count()
+            == 1
+        ), "collection should have 1 open ticket with hostname foo.gov"
+        ticket = database_w_hostname_vulns.tickets.find_one(
+            {"open": True, "hostname": "foo.gov"}
+        )
         assert (
             ticket["events"][-1]["action"] == TICKET_EVENT.REOPENED
         ), "last event of ticket should be reopened"
-        assert database_w_hostname_vulns.tickets.find({"open": True}).count() == 1, "collection should have 1 open ticket"
+        assert (
+            database_w_hostname_vulns.tickets.find({"open": True}).count() == 1
+        ), "collection should have 1 open ticket"
 
         vtm.open_ticket(VULN_5, "test vuln re-detected")
-        assert database_w_hostname_vulns.tickets.find({"open": True, "hostname": "foo.gov"}).count() == 1, "collection should have 1 open ticket with hostname foo.gov"
-        ticket = database_w_hostname_vulns.tickets.find_one({"open": True, "hostname": "foo.gov"})
+        assert (
+            database_w_hostname_vulns.tickets.find(
+                {"open": True, "hostname": "foo.gov"}
+            ).count()
+            == 1
+        ), "collection should have 1 open ticket with hostname foo.gov"
+        ticket = database_w_hostname_vulns.tickets.find_one(
+            {"open": True, "hostname": "foo.gov"}
+        )
         assert (
             ticket["events"][-1]["action"] == TICKET_EVENT.VERIFIED
         ), "last event of ticket should be reopened"
-        assert database_w_hostname_vulns.tickets.find({"open": True}).count() == 1, "collection should have 1 open ticket"
+        assert (
+            database_w_hostname_vulns.tickets.find({"open": True}).count() == 1
+        ), "collection should have 1 open ticket"
 
         vtm.open_ticket(VULN_6, "test vuln re-detected")
-        assert database_w_hostname_vulns.tickets.find({"open": True, "hostname": "bar.gov"}).count() == 1, "collection should have 1 open ticket with hostname bar.gov"
-        ticket = database_w_hostname_vulns.tickets.find_one({"open": True, "hostname": "bar.gov"})
+        assert (
+            database_w_hostname_vulns.tickets.find(
+                {"open": True, "hostname": "bar.gov"}
+            ).count()
+            == 1
+        ), "collection should have 1 open ticket with hostname bar.gov"
+        ticket = database_w_hostname_vulns.tickets.find_one(
+            {"open": True, "hostname": "bar.gov"}
+        )
         assert (
             ticket["events"][-1]["action"] == TICKET_EVENT.REOPENED
         ), "last event of ticket should be reopened"
-        assert database_w_hostname_vulns.tickets.find({"open": True}).count() == 2, "collection should have 2 open tickets"
+        assert (
+            database_w_hostname_vulns.tickets.find({"open": True}).count() == 2
+        ), "collection should have 2 open tickets"
 
         vtm.open_ticket(VULN_6, "test vuln re-detected")
-        assert database_w_hostname_vulns.tickets.find({"open": True, "hostname": "bar.gov"}).count() == 1, "collection should have 1 open ticket with hostname bar.gov"
-        ticket = database_w_hostname_vulns.tickets.find_one({"open": True, "hostname": "bar.gov"})
+        assert (
+            database_w_hostname_vulns.tickets.find(
+                {"open": True, "hostname": "bar.gov"}
+            ).count()
+            == 1
+        ), "collection should have 1 open ticket with hostname bar.gov"
+        ticket = database_w_hostname_vulns.tickets.find_one(
+            {"open": True, "hostname": "bar.gov"}
+        )
         assert (
             ticket["events"][-1]["action"] == TICKET_EVENT.VERIFIED
         ), "last event of ticket should be reopened"
-        assert database_w_hostname_vulns.tickets.find({"open": True}).count() == 2, "collection should have 2 open tickets"
+        assert (
+            database_w_hostname_vulns.tickets.find({"open": True}).count() == 2
+        ), "collection should have 2 open tickets"
 
 
 class TestIPPortNonVulnScanTickets:

--- a/cyhy/util/util.py
+++ b/cyhy/util/util.py
@@ -282,10 +282,10 @@ def warn_and_confirm(message):
 
 def parse_domains(domains):
     """Parses a list of domains and determines which are valid and which are not.
-    
+
     Args:
         domains (list): A list of domain strings to parse.
-    
+
     Returns:
         valid_domains (set): A set of valid domain strings.
         invalid_domains (set): A set of invalid domain strings.


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a GitHub Actions workflow to automatically run `black` against the project and commit any changes.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This will help ensure that this Python 2 project remains formatted even without our `pre-commit` configuration. It mirrors what was added in https://github.com/cisagov/cyhy-commander/pull/19.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

👀 after copying the workflow as merged in https://github.com/cisagov/cyhy-commander/pull/19.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
