### PR TITLE
Disallow adding non-resolvable hostnames and hostnames that resolve to an "owned" IP in `cyhy-domain`

### DIFF
--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -114,11 +114,11 @@ def add(db, owner, domains):
         if owned_domains:
             print "\nDomains already owned by other CyHy entities:"
             for d in sorted(owned_domains):
-                print "%s" % d
+                print d
         if unresolvable_domains:
             print "\nDomains that do not resolve to any IPv4 addresses:"
             for d in sorted(unresolvable_domains):
-                print "%s" % d
+                print d
         print "\nEXITING without adding any domains."
         sys.exit(-1)
 

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -90,14 +90,36 @@ def get_ipv4_addresses(hostname):
 
 def add(db, owner, domains):
     domain_owners = get_existing_domains_and_owners(db)
+
+    owned_domains = []
+    unresolvable_domains = []
     
-    domain_conflict = False
+    domain_problem = False
     for d in domains:
+        # Check if domain is already owned by another CyHy entity
         if d in domain_owners:
-            domain_conflict = True
+            domain_problem = True
             print "ERROR - %s is already owned by: %s" % (d, domain_owners[d])
+            owned_domains.append(d)
+            continue
+
+        # Check if domain resolves to at least one IPv4 address
+        if not get_ipv4_addresses(d):
+            domain_problem = True
+            print "ERROR - %s does not resolve to any IPv4 addresses" % d
+            unresolvable_domains.append(d)
     
-    if domain_conflict:
+    if domain_problem:
+        print "\n=== Summary of domain errors ==="
+        if owned_domains:
+            print "\nDomains already owned by other CyHy entities:"
+            for d in sorted(owned_domains):
+                print "%s" % d
+        if unresolvable_domains:
+            print "\nDomains that do not resolve to any IPv4 addresses:"
+            for d in sorted(unresolvable_domains):
+                print "%s" % d
+        print "\nEXITING without adding any domains."
         sys.exit(-1)
 
     request = db.RequestDoc.get_by_owner(owner)

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -28,7 +28,7 @@ Notes:
 import sys
 
 # Third-Party Libraries
-from dns import resolver, exception
+from dns import exception, resolver
 from docopt import docopt
 from netaddr import IPAddress
 

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -73,10 +73,9 @@ def get_existing_domains_and_owners(db):
 
 def get_ipv4_addresses(hostname):
     """Return a set of IPv4 addresses for the given hostname."""
+    ip_set = set()
     try:
         answers = resolver.query(hostname, 'A')
-        ip_list = [IPAddress(answer.address) for answer in answers]
-        return set(ip_list)
     # Could not resolve domain name
     except resolver.NoNameservers as e:
         print "Warning: No nameservers available to resolve %s" % hostname
@@ -87,7 +86,11 @@ def get_ipv4_addresses(hostname):
     except exception.DNSException as e:
         print "Warning: Unexpected DNS exception for %s" % hostname
         print str(e)
-    return set()
+    else:
+        ip_list = [IPAddress(answer.address) for answer in answers]
+        ip_set = set(ip_list)
+    finally:
+        return ip_set
 
 
 def add(db, owner, domains, disallow_owned_ips):

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -243,7 +243,7 @@ def move(db, orig_owner, new_owner, domains_to_move):
 
 
 def main():
-    args = docopt(__doc__, version="v1.1.0")
+    args = docopt(__doc__, version="v1.2.0")
 
     db = database.db_from_config(args["--section"], args["--config-file"])
 

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -14,6 +14,8 @@ Options:
   -c FILE --config-file=FILE     Configuration file to use.
   -f FILENAME --file=FILENAME    Read domains from a file.
   -h --help                      Show this screen.
+  -o --no-owned                  Do not add domains that resolve to an IP owned
+                                 by a non-default CyHy entity.
   -s SECTION --section=SECTION   Configuration section to use.
   --version                      Show version.
 
@@ -88,12 +90,13 @@ def get_ipv4_addresses(hostname):
     return set()
 
 
-def add(db, owner, domains):
+def add(db, owner, domains, disallow_owned_ips):
     domain_owners = get_existing_domains_and_owners(db)
 
     owned_domains = []
+    resolves_to_owned_ip_domains = []
     unresolvable_domains = []
-    
+
     domain_problem = False
     for d in domains:
         # Check if domain is already owned by another CyHy entity
@@ -104,10 +107,24 @@ def add(db, owner, domains):
             continue
 
         # Check if domain resolves to at least one IPv4 address
-        if not get_ipv4_addresses(d):
+        domain_ips = get_ipv4_addresses(d)
+        if not domain_ips:
             domain_problem = True
             print "ERROR - %s does not resolve to any IPv4 addresses" % d
             unresolvable_domains.append(d)
+            continue
+
+        # If --no-owned option was specified, check if any resolved IPs for this
+        # domain are already owned by a CyHy entity other than the DEFAULT_OWNER
+        # and if so, do not add the domain.
+        if disallow_owned_ips:
+            for ip in domain_ips:
+                existing_hostdoc = db.HostDoc.get_by_ip(ip)
+                if existing_hostdoc and existing_hostdoc["owner"] != DEFAULT_OWNER:
+                    domain_problem = True
+                    print "ERROR - %s resolves to IP %s owned by %s in CyHy" % (d, ip, existing_hostdoc["owner"])
+                    resolves_to_owned_ip_domains.append(d)
+                    break
     
     if domain_problem:
         print "\n=== Summary of domain errors ==="
@@ -118,6 +135,10 @@ def add(db, owner, domains):
         if unresolvable_domains:
             print "\nDomains that do not resolve to any IPv4 addresses:"
             for d in sorted(unresolvable_domains):
+                print d
+        if resolves_to_owned_ip_domains:
+            print "\nDomains that resolve to an IP already owned by a CyHy entity:"
+            for d in sorted(resolves_to_owned_ip_domains):
                 print d
         print "\nEXITING without adding any domains."
         sys.exit(-1)
@@ -327,7 +348,7 @@ def main():
     domains = list(valid_domains)
 
     if args["add"]:
-        add(db, args["OWNER"], domains)
+        add(db, args["OWNER"], domains, args["--no-owned"])
     elif args["check"]:
         check(db, domains)
     elif args["move"]:

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -26,7 +26,9 @@ Notes:
 import sys
 
 # Third-Party Libraries
+from dns import resolver, exception
 from docopt import docopt
+from netaddr import IPAddress
 
 # cisagov Libraries
 from cyhy.core.common import *
@@ -65,6 +67,25 @@ def get_existing_domains_and_owners(db):
         for h in r["hostnames"]:
             domain_owners[h] = "%s (%s)" % (r["agency"]["name"], r["_id"])
     return domain_owners
+
+
+def get_ipv4_addresses(hostname):
+    """Return a set of IPv4 addresses for the given hostname."""
+    try:
+        answers = resolver.query(hostname, 'A')
+        ip_list = [IPAddress(answer.address) for answer in answers]
+        return set(ip_list)
+    # Could not resolve domain name
+    except resolver.NoNameservers as e:
+        print "Warning: No nameservers available to resolve %s" % hostname
+        print str(e)
+    except resolver.Timeout as e:
+        print "Warning: DNS query timed out for %s" % hostname
+        print str(e)
+    except exception.DNSException as e:
+        print "Warning: Unexpected DNS exception for %s" % hostname
+        print str(e)
+    return set()
 
 
 def add(db, owner, domains):


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR adds the following new features to the `cyhy-domain` script:
* If a hostname to be added to a CyHy entity does not resolve to at least one IPv4 address, it will not be added
* A new `--no-owned` option was added.  When used with `cyhy-domain add`, it prevents a hostname from being added if the hostname resolves to an IP address that is already "owned" in CyHy by an entity other than the default `CYHY` entity.
* If any domain-related errors occur with `cyhy-domain add`, a summary of those errors is output like this:
```
ERROR - foo.gov does not resolve to any IPv4 addresses
ERROR - bar.gov is already owned by: Entity1 (E1)
ERROR - baz.gov resolves to IP xxx.xxx.xxx.xxx owned by E2 in CyHy
ERROR - foobar.gov resolves to IP xxx.xxx.xxx.xxx owned by E3 in CyHy
ERROR - foobarbaz.gov is already owned by: Entity4 (E4)
ERROR - foobarbazoo.gov does not resolve to any IPv4 addresses

=== Summary of domain errors ===

Domains already owned by other CyHy entities:
bar.gov
foobarbaz.gov

Domains that do not resolve to any IPv4 addresses:
foo.gov
foobarbazoo.gov

Domains that resolve to IPs owned by other CyHy entities:
baz.gov
foobar.gov

EXITING without adding any domains.
```

Note: This PR was built on top of the changes in #121.  To view the differences from only this PR, click [here](https://github.com/cisagov/cyhy-core/compare/improvement/close-tix-for-removed-hostnames...improvement/disallow-nonresolvable-hostnames).

## 💭 Motivation and context ##

These additional features were requested by CyHy Ops team to:
* Ensure that only resolvable hostnames get added into CyHy inventory; this will reduce wasted time resolving non-resolvable hostnames every time the `cyhy-domainsync` ("housekeeping") script is run
* Have the ability to avoid adding any hostnames that resolve to IPs that are already "owned" in CyHy; this will help them with BOD compliance efforts

Resolves https://github.com/cisagov/cyhy-core/issues/119.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested the new code locally and verified that it operates as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).   This PR will be included in release `1.1.10`.
- [x] Deploy this change to Production.
