### PR TITLE
Adjust how tally documents are updated

### DIFF
--- a/cyhy/db/chdatabase.py
+++ b/cyhy/db/chdatabase.py
@@ -82,14 +82,12 @@ class CHDatabase(object):
         changed_count = self.__db.HostDoc.increase_ready_hosts(owner, stage, count)
         tally = self.__db.TallyDoc.get_by_owner(owner)
         tally.transfer(stage, STATUS.WAITING, stage, STATUS.READY, changed_count)
-        tally.save()
         return changed_count
 
     def decrease_ready_hosts(self, owner, stage, count):
         changed_count = self.__db.HostDoc.decrease_ready_hosts(owner, stage, count)
         tally = self.__db.TallyDoc.get_by_owner(owner)
         tally.transfer(stage, STATUS.READY, stage, STATUS.WAITING, changed_count)
-        tally.save()
         return changed_count
 
     def balance_ready_hosts(self):
@@ -160,7 +158,6 @@ class CHDatabase(object):
             )
             return
         tally.transfer(prev_stage, prev_status, new_stage, new_status, 1)
-        tally.save()
 
     def update_host_priority_and_reschedule(self, ip):
         """Update host priority and reschedule host."""

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1485,8 +1485,14 @@ class TallyDoc(RootDoc):
         )
 
     def transfer(self, from_stage, from_status, to_stage, to_status, delta):
-        self["counts"][from_stage][from_status] -= delta
-        self["counts"][to_stage][to_status] += delta
+        from_field = "counts.{}.{}".format(from_stage, from_status)
+        to_field = "counts.{}.{}".format(to_stage, to_status)
+        self.collection.update_one(
+            {"_id": self["_id"]}, {"$inc": {from_field: -delta, to_field: delta}}
+        )
+
+        # ensure the local copy is up-to-date
+        self.reload()
 
     def get_by_owner(self, owner):
         return self.find_one({"_id": owner})

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1488,7 +1488,11 @@ class TallyDoc(RootDoc):
         from_field = "counts.{}.{}".format(from_stage, from_status)
         to_field = "counts.{}.{}".format(to_stage, to_status)
         self.collection.update_one(
-            {"_id": self["_id"]}, {"$inc": {from_field: -delta, to_field: delta}}
+            {"_id": self["_id"]},
+            {
+                "$inc": {from_field: -delta, to_field: delta},
+                "$set": {"last_change": util.utcnow()},
+            },
         )
 
         # ensure the local copy is up-to-date

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.1.10",
+    version="1.1.11",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes how we modify tally documents. The current functionality modifies the retrieved document locally and requires it to be saved for it to be reflected in the database. This pull request changes it to instead use the MongoDB `$inc` operator in an update operation to adjust tally values. 
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

During testing for https://github.com/cisagov/cyhy-commander/pull/15 we found that there is a race condition situation that results in negative tally values when multiple jobs are trying to update tally values at the same time. This change is being made in an API-compatible manner, but a future implementation that is not API-compatible should move this functionality into a class method to avoid both the initial document pull as well as the reload to ensure the local copy has the correct values.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this in @dav3r's test environment and confirmed that tally values were being adjusted as expected. We will need to run this in the production environment to ensure that no negative tally values appear with this change in place.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
