### PR TITLE
Adjust the `TallyDoc.sync()` method to be thread-safe

### DIFF
--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1509,9 +1509,14 @@ class TallyDoc(RootDoc):
     def sync(self, db):
         for stage in list(STAGE):
             for status in list(STATUS):
+                count_field = "counts.{}.{}".format(stage, status)
                 count = db.HostDoc.get_count(self["_id"], stage, status)
-                self["counts"][stage][status] = count
-        self.save_without_timestamp_change()
+                self.collection.update_one(
+                    {"_id": self["_id"]},
+                    {
+                        "$set": {count_field: count},
+                    },
+                )
 
 
 class SnapshotDoc(RootDoc):

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1521,6 +1521,7 @@ class TallyDoc(RootDoc):
         # ensure the local copy is up-to-date
         self.reload()
 
+
 class SnapshotDoc(RootDoc):
     __collection__ = SNAPSHOT_COLLECTION
     structure = {

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1518,6 +1518,8 @@ class TallyDoc(RootDoc):
                     },
                 )
 
+        # ensure the local copy is up-to-date
+        self.reload()
 
 class SnapshotDoc(RootDoc):
     __collection__ = SNAPSHOT_COLLECTION

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.1.11",
+    version="1.1.12",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes the `TallyDoc.sync()` method similarly to how the `TallyDoc.transfer()` method was updated in #124 to perform an update operation instead of making local changes and then saving them.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We're still troubleshooting entity tallies having negative values and after looking at the codebase some more I determined that this method _could_ cause issues. The `TallyDoc.sync()` method is used by the `cyhy-domainsync`, `cyhy-ip`, `cyhy-suborg`, and `cyhy-tool` command-line scripts. After reviewing those four scripts I determined that the way it is used automatically as part of the `cyhy-domainsync` script _could_ cause a race condition if the entity it is modifying is also being updated by jobs being processed by the [commander](https://github.com/cisagov/cyhy-commander).

> [!NOTE]
> It might be worth looking at if we can abuse aggregation pipelining to combine the host count lookup with the update operation. However, this is only easily doable (with the `$merge` operator) in MongoDB 4.2+, which we are not using.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I updated the code in @dav3r's test environment and ran a `cyhy-tool status-all --sync` without issue.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
