### PR TITLE
Add `cyhy-domainsync` option to skip "owned" resolved IPs

### DIFF
--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -175,8 +175,9 @@ def main():
                         print("Created HostDoc owned by: " + default_owner)
                         continue
                     else:
-                        # If the HostDoc exists and is owned by a non-default
-                        # CyHy entity, skip this IP address
+                        # If the --no-owned option is set and a HostDoc exists
+                        # that is owned by a non-default CyHy entity, skip this
+                        # IP address
                         if args["--no-owned"] and host_doc["owner"] != default_owner:
                             print("Skipping IP; --no-owned option enabled and found HostDoc owned by " + host_doc["owner"])
                             continue

--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -10,6 +10,8 @@ Usage:
 Options:
   -f FILE --config-file=FILE      Configuration file to use.
   -h --help                       Show this screen.
+  -n --no-owned                   Skip resolved IP addresses that are owned by a
+                                  CyHy entity other than the default owner.
   -o OWNER --default-owner=OWNER  Default owner to use for new HostDocs [default: CYHY].
   -r IP --resolver=IP             IP address of DNS resolver to use.
   -s SECTION --section=SECTION    Configuration section to use.
@@ -173,6 +175,11 @@ def main():
                         print("Created HostDoc owned by: " + default_owner)
                         continue
                     else:
+                        # If the HostDoc exists and is owned by a non-default
+                        # CyHy entity, skip this IP address
+                        if args["--no-owned"] and host_doc["owner"] != default_owner:
+                            print("Skipping IP; --no-owned option enabled and found HostDoc owned by " + host_doc["owner"])
+                            continue
                         print("Found HostDoc owned by: " + host_doc["owner"])
 
                     # The HostDoc did exist, so add the request ID and domain to the list of owners

--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -86,7 +86,7 @@ def close_tickets(db, ip, hostname, reason):
     return result["nModified"]
 
 def main():
-    args = docopt(__doc__, version="v1.0.3")
+    args = docopt(__doc__, version="v1.0.4")
 
     # Dictionary to track certain DNS exceptions encountered during processing
     dns_exceptions = {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.1.12",
+    version="1.1.13",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a `--no-owned` option to `cyhy-domainsync` that (when enabled) **does not** assign a hostname to an existing HostDoc if the HostDoc is already owned by an existing CyHy entity (other than the default `CYHY` entity).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

A similar change was made to `cyhy-domain` in https://github.com/cisagov/cyhy-core/pull/122, but it's possible for this situation (adding a hostname to an IP that's owned by an existing non-default CyHy entity) to occur when `cyhy-domainsync` runs, so we want to update `cyhy-domainsync` to be able to prevent this from happening, if so desired.

Resolves #126.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested in a dev environment and confirmed the following:
- [x] When `--no-owned` option **is set**, a hostname that resolves to an IP address that is "owned" in CyHy by a non-`CYHY` entity **is not added** to the HostDoc for that IP _(different from current behavior)_.
- [x] When `--no-owned` option **is set**, a hostname that resolves to an IP address that is "owned" in CyHy by the default `CYHY` entity **is added** to the HostDoc for that IP _(no change from current behavior)_.
- [x] When `--no-owned` option **is not set**, a hostname that resolves to an IP address that is "owned" in CyHy by a non-`CYHY` entity **is added** to the HostDoc for that IP _(no change from current behavior)_.
- [x] When `--no-owned` option **is not set**, a hostname that resolves to an IP address that is "owned" in CyHy by the default `CYHY` entity **is added** to the HostDoc for that IP _(no change from current behavior)_.
- [x] When `--no-owned` option **is not set**, a hostname that resolves to an IP address that is not "owned" in CyHy by anyone **is added** to a newly-created HostDoc (owned by the default `CYHY` entity) for that IP _(no change from current behavior)_.
- [x] When `--no-owned` option **is set**, a hostname that resolves to an IP address that is not "owned" in CyHy by anyone **is added** to a newly-created HostDoc (owned by the default `CYHY` entity) for that IP _(no change from current behavior)_.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
- [x] Deploy this change to Production and manually enable the `--no-owned` flag (confirm with CyHy Ops team first)
