### PR TITLE
Make `cyhy-ip` aware of default CyHy owner

### DIFF
--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -148,10 +148,12 @@ def print_cidrs(cidrs, indent=0):
 
 
 def check(db, cidrs):
-    intersections = db.RequestDoc.get_all_intersections(
-        cidrs
-    )  # intersections from database
-    intersections.update(get_special_intersections(cidrs))  # intersections with RFCs
+    # Intersections with IPs owned by any owner other than the default owner
+    intersections = db.RequestDoc.get_all_intersections(cidrs)
+    # Intersections with RFCs
+    intersections.update(get_special_intersections(cidrs))
+    # Intersections with IPs owned by the default owner
+    intersections.update(get_default_owner_intersections(db, cidrs))
     print_intersections(intersections)
     matched = IPSet()
     for request, intersecting_cidrs in intersections.iteritems():

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -173,17 +173,34 @@ def get_default_owner_ip_set(db):
 
 
 def do_list(db, owner):
-    request = db.RequestDoc.find_one({"_id": owner})
-    if request:
-        for i in request["networks"]:
-            print i
+    if owner != DEFAULT_OWNER:
+        request = db.RequestDoc.find_one({"_id": owner})
+        if request:
+            for i in request["networks"]:
+                print i
+        else:
+            print "ERROR: Organization %s not found in DB" % owner
     else:
-        print "ERROR: Organization %s not found in DB" % owner
+        # List default owner CIDRs
+        for i in get_default_owner_ip_set(db).iter_cidrs():
+            print i
+
 
 
 def do_list_all(db):
+    # Intersections with IPs owned by any owner other than the default owner
     intersections = db.RequestDoc.get_all_intersections(IPSet(["0.0.0.0/0"]))
     print_intersections(intersections)
+
+    # List default owner CIDRs
+    default_owner_name = db.RequestDoc.find_one({"_id": DEFAULT_OWNER})["agency"]["name"]
+    default_owner_ip_set = get_default_owner_ip_set(db)
+    print "# %s (%s): %s" % (
+        default_owner_name,
+        DEFAULT_OWNER,
+        "{:,}".format(len(default_owner_ip_set)),
+    )
+    print_cidrs(default_owner_ip_set, indent=1)
 
 
 def add(db, owner, cidrs):

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -206,9 +206,12 @@ def do_list_all(db):
 
 
 def add(db, owner, cidrs):
-    intersections = db.RequestDoc.get_all_intersections(
-        cidrs
-    )  # intersections from database
+    if owner == DEFAULT_OWNER:
+        print "Cannot continue!\nNot allowed to add addresses to the default owner (%s)." % DEFAULT_OWNER
+        sys.exit(-1)
+
+    # Intersections with IPs owned by any owner other than the default owner
+    intersections = db.RequestDoc.get_all_intersections(cidrs)
     geo_loc_db = GeoLocDB()
     restricted_dict = defaultdict(lambda: IPSet())
     for ip in cidrs:
@@ -233,6 +236,10 @@ def add(db, owner, cidrs):
         print "Cannot continue!\nSome addresses already allocated or reserved:"
         print_intersections(intersections)
         sys.exit(-1)
+
+    # Get set of IPs owned by default owner
+    default_owner_ip_set = get_default_owner_ip_set(db)
+
     request = db.RequestDoc.find_one({"_id": owner})
     # init new hosts documents
     # get the init_stage, if it doesn't have one assume NETSCAN1
@@ -240,17 +247,36 @@ def add(db, owner, cidrs):
     pbar = pb.ProgressBar(widgets=PB_INIT_WIDGETS, maxval=len(cidrs)).start()
     pbar.widgets[0] = "Adding %s: " % owner
     i = 0
+    default_owner_modified = False
     for ip in cidrs:
-        location = geo_loc_db.lookup(ip)
-        host = db.HostDoc()
-        host.init(ip, owner, location, stage)
-        host.save()
+        # Check if IP is owned by the default owner
+        if ip in default_owner_ip_set:
+            # Update existing host document from default owner to new owner
+            host = db.HostDoc.get_by_ip(ip)
+            if not host:
+                print "ERROR: Host document for %s not found, even though it is owned by %s!" % (str(ip), DEFAULT_OWNER)
+                sys.exit(-1)
+            host["owner"] = owner
+            host.save()
+            print "Warning: %s was owned by %s, now owned by %s." % (str(ip), DEFAULT_OWNER, owner)
+            default_owner_modified = True
+        else:
+            # Create new host document
+            location = geo_loc_db.lookup(ip)
+            host = db.HostDoc()
+            host.init(ip, owner, location, stage)
+            host.save()
         i += 1
         pbar.update(i)
     # update request with new networks
     request.add_networks(cidrs)
     request.save()
-    print "IPs added to request, and initialized.  Tally sync required to start scan of new IPs."
+    if default_owner_modified:
+        # Sync default owner tally if any of its IPs were modified
+        default_owner_tally = db.TallyDoc.get_by_owner(DEFAULT_OWNER)
+        default_owner_tally.sync(db)
+        print "Default owner (%s) IPs modified and tally synchronized." % DEFAULT_OWNER
+    print "IPs added to %s request and initialized.  Tally sync for %s required to start scan of new IPs." % (owner, owner)
     sys.exit(0)
 
 

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -355,6 +355,10 @@ def compare(db, owner, new_net_set):
 
 
 def move(db, orig_owner, new_owner, networks_to_move):
+    if orig_owner == DEFAULT_OWNER or new_owner == DEFAULT_OWNER:
+        print "ERROR: Not allowed to move addresses to or from the default owner (%s). EXITING without making any changes." % DEFAULT_OWNER
+        sys.exit(-1)
+
     if orig_owner == new_owner:
         print "ERROR: OWNER is the same as NEW_OWNER (%s). EXITING without making any changes." % orig_owner
         sys.exit(-1)

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -314,7 +314,10 @@ def wrapped_remove(db, owner, cidrs):
 
 
 def compare(db, owner, new_net_set):
-    old_net_set = db.RequestDoc.find_one({"_id": owner}).networks
+    if owner != DEFAULT_OWNER:
+        old_net_set = db.RequestDoc.find_one({"_id": owner}).networks
+    else:
+        old_net_set = get_default_owner_ip_set(db)
 
     added = new_net_set - old_net_set
     removed = old_net_set - new_net_set

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -255,6 +255,10 @@ def add(db, owner, cidrs):
 
 
 def remove(db, owner, cidrs):
+    if owner == DEFAULT_OWNER:
+        print "Cannot continue!\nNot allowed to remove addresses from the default owner (%s)." % DEFAULT_OWNER
+        sys.exit(-1)
+
     intersections = db.RequestDoc.get_all_intersections(cidrs)
     if len(intersections) == 0:
         print "Cannot continue!\nAddress is not allocated."

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -439,9 +439,10 @@ def move(db, orig_owner, new_owner, networks_to_move):
 
 
 def setstage(db, stage, cidrs):
-    intersections = db.RequestDoc.get_all_intersections(
-        cidrs
-    )  # intersections from database
+    # intersections with IPs owned by any owner other than the default owner
+    intersections = db.RequestDoc.get_all_intersections(cidrs)  
+    # intersections with IPs owned by the default owner
+    intersections.update(get_default_owner_intersections(db, cidrs))
     matched = IPSet()
     for request, intersecting_cidrs in intersections.iteritems():
         matched.update(intersecting_cidrs)

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -29,7 +29,7 @@ import sys
 
 # Third-Party Libraries
 from docopt import docopt
-from netaddr import ip, IPNetwork, IPRange, IPSet
+from netaddr import ip, IPAddress, IPNetwork, IPRange, IPSet
 import progressbar as pb
 
 # cisagov Libraries
@@ -109,6 +109,17 @@ def read_file(filename):
     return parse_addresses(f.readlines())
 
 
+def get_default_owner_intersections(db, cidrs):
+    results = {}  # {request: IPSet of intersections}
+    default_owner_request = db.RequestDoc.get_by_owner(DEFAULT_OWNER)
+    if default_owner_request:
+        default_owner_cidrs = get_default_owner_ip_set(db)
+        intersection = default_owner_cidrs & cidrs
+        if intersection:
+            results[default_owner_request] = intersection
+    return results
+
+
 def get_special_intersections(cidrs):
     results = {}  # {request: IPSet of intersections}
     for description, special_set in SPECIAL_RANGES.items():
@@ -149,6 +160,16 @@ def check(db, cidrs):
     if unmatched:
         print "Unmatched: %s" % "{:,}".format(len(unmatched))
         print_cidrs(unmatched, indent=1)
+
+
+def get_default_owner_ip_set(db):
+    # Return IPSet of all IP addresses owned by default owner
+    default_owner_ips = [
+        IPAddress(h["_id"]) for h in db.HostDoc.find(
+            {"owner": DEFAULT_OWNER}, {"_id": 1}
+        )
+    ]
+    return IPSet(default_owner_ips)
 
 
 def do_list(db, owner):

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -534,7 +534,7 @@ def setstage(db, stage, cidrs):
 
 
 def main():
-    args = docopt(__doc__, version="v0.0.1")
+    args = docopt(__doc__, version="v1.0.0")
 
     db = database.db_from_config(args["--section"])
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR makes changes to various `cyhy-ip` functions in order to make them work as intended (or not work, in certain cases - see below) when interacting with the default CyHy owner (`CYHY`).  Specifically:
* `cyhy-ip add`: 
    * Displays an error message that addresses cannot be manually added to the default owner
    * When adding an IP to another entity that is currently owned by the default owner, modifies the owner of the existing HostDoc without changing any other info from the HostDoc (aside from the `last_change` timestamp) and displays a warning message that this is happening
* `cyhy-ip check`: Checks for addresses owned by the default owner
* `cyhy-ip list`: Lists addresses owned by the default owner
* `cyhy-ip list-all`: Lists addresses owned by the default owner
* `cyhy-ip remove`: Prints an error message if attempting to remove addresses owned by the default owner
* `cyhy-ip compare`: Supports comparison with addresses owned by the default owner
* `cyhy-ip move`: Prints an error message if attempting to move addresses to or from the default owner
* `cyhy-ip setstage`: Supports setting the scan stage for addresses owned by the default owner

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Some of these changes were specifically requested by the CyHy Ops team.  The other changes were made so that `cyhy-ip` operates in a sane and consistent way with respect to the default CyHy owner.

Resolves #127.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

The following items were validated:
- [x] `cyhy-ip add <OWNER> <ADDRESSES>` for a `CYHY`-owned IP displays a warning message that the IP is owned by `CYHY`
- [x] `cyhy-ip add <OWNER> <ADDRESSES>` for a `CYHY`-owned IP modifies the owner of the existing HostDoc without changing any other info from the HostDoc (aside from the `last_change` timestamp)
- [x] `cyhy-ip add <OWNER> <ADDRESSES>` for a non-`CYHY`-owned IP operates the same as it does now
- [x] `cyhy-ip add CYHY <ADDRESSES>` displays an error message that addresses cannot be manually added to the `CYHY` owner
- [x] `cyhy-ip check <ADDRESSES>` for `CYHY`-owned addresses correctly displays ownership or lack thereof by `CYHY`
- [x] `cyhy-ip compare CYHY <ADDRESSES>` correctly compares the addresses to those owned by `CYHY`
- [x] `cyhy-ip list CYHY` displays IPs owned by `CYHY`
- [x] `cyhy-ip list-all` displays IPs owned by `CYHY` (as well as all other entities)
- [x] `cyhy-ip move` displays an error message when attempting to move IPs to or from the default `CYHY` owner
- [x] `cyhy-ip remove CYHY <ADDRESSES>` displays an error message that IPs owned by `CYHY` cannot be manually removed
- [x] `cyhy-ip setstage <STAGE> <ADDRESSES>` correctly sets the scan stage for IPs owned by `CYHY`

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
