### PR TITLE
Correctly preserve tickets with null hostnames

### DIFF
--- a/bin/cyhy-ticket
+++ b/bin/cyhy-ticket
@@ -74,7 +74,14 @@ def print_ticket_details(tickets):
         t["open_flag_str"] = str(t["open"])
         t["fp_flag_str"] = str(t["false_positive"])
         t["severity_str"] = SEVERITY_LEVELS[t["details"]["severity"]]
-        t["hostname"] = t.get("hostname", "")
+        # If hostname field is not present (i.e. tickets created before
+        # hostnames were supported), set hostname to None (as opposed to the ""
+        # empty string).  We don't want to set the hostname to "" in case this
+        # ticket is saved back to the DB (i.e. when modifying the false_positive
+        # flag) because the commander could potentially create a new ticket
+        # whose only difference would be the hostname set to None and we want to
+        # avoid that situation.
+        t["hostname"] = t.get("hostname", None)
         if t["false_positive"]:
             t["fp_effective_date"], t["fp_expiration_date"] = t.false_positive_dates
             print "{_id:<26}{open_flag_str:<7}{fp_flag_str:<7}{time_opened:%Y-%m-%d %H:%M}   {severity_str:<10}{fp_effective_date:%Y-%m-%d}    {fp_expiration_date:%Y-%m-%d}     {port:<7}{protocol:<10}{hostname:<48}  {details[name]}".format(

--- a/bin/cyhy-ticket
+++ b/bin/cyhy-ticket
@@ -252,7 +252,7 @@ def set_false_positive(db, cidrs):
 
 
 def main():
-    args = docopt(__doc__, version="v1.0.0")
+    args = docopt(__doc__, version="v1.0.1")
     db = database.db_from_config(args["--section"])
 
     nets = parse_addresses(args["ADDRESSES"])

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.1.13",
+    version="1.1.14",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION

<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies `cyhy-ticket` such that if the `hostname` field is null or not present when modifying the ticket's `false_positive` flag, the hostname field is set to `None` (as opposed to the `""` empty string).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We don't want to set the hostname to `""` in case this ticket is saved back to the DB (i.e. when modifying the `false_positive` flag) because the commander could potentially create a new ticket whose only difference would be the hostname set to `None` and we want to avoid that situation.

Resolves #130.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this locally and verified that the hostname value is preserved as `null` when setting the `false_positive` flag. 

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
