### PR TITLE
Allow specifying the location of the MaxMind GeoIP2 database file in scripts

### DIFF
--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -87,7 +87,7 @@ def close_tickets(db, ip, hostname, reason):
     return result["nModified"]
 
 def main():
-    args = docopt(__doc__, version="v1.0.4")
+    args = docopt(__doc__, version="v1.0.5")
 
     # Dictionary to track certain DNS exceptions encountered during processing
     dns_exceptions = {

--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -9,6 +9,7 @@ Usage:
 
 Options:
   -f FILE --config-file=FILE      Configuration file to use.
+  -g FILE --geoip2-file=FILE      MaxMind GeoIP2 database file to use.
   -h --help                       Show this screen.
   -n --no-owned                   Skip resolved IP addresses that are owned by a
                                   CyHy entity other than the default owner.
@@ -109,7 +110,7 @@ def main():
         print("Using default owner: " + default_owner)
 
         # Initialize the geo-location database
-        geo_loc_db = GeoLocDB()
+        geo_loc_db = GeoLocDB(database_path=args["--geoip2-file"])
 
         # Look up starting stage for default owner
         default_owner_req = db.RequestDoc.get_by_owner(default_owner)

--- a/bin/cyhy-geoip
+++ b/bin/cyhy-geoip
@@ -12,6 +12,7 @@ Arguments:
 Options:
   -h, --help                     Show this screen.
   --version                      Show version.
+  -g FILE --geoip2-file=FILE     MaxMind GeoIP2 database file to use.
   -s SECTION, --section=SECTION  Configuration section to use.
   -d, --debug                    Output debug messages.
   --live-only                    Update only hosts that are up.
@@ -168,7 +169,7 @@ def main():
     args = docopt(__doc__, version="v0.0.1")
 
     cyhy_db = database.db_from_config(args["--section"])
-    geoip_db = GeoLocDB()
+    geoip_db = GeoLocDB(args["--geoip2-file"])
 
     # Set up logging
     logging_setup(args["--debug"])

--- a/bin/cyhy-geoip
+++ b/bin/cyhy-geoip
@@ -166,7 +166,7 @@ def do_update(chdb, gidb, up_only=False, owner=None):
 
 
 def main():
-    args = docopt(__doc__, version="v0.0.1")
+    args = docopt(__doc__, version="v1.0.0")
 
     cyhy_db = database.db_from_config(args["--section"])
     geoip_db = GeoLocDB(args["--geoip2-file"])

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -12,6 +12,7 @@ Options:
 
   -i STAGE --init-stage STAGE    Override the init-stage specified in file
   -f --force                     Force import of existing request, destroying original
+  -g FILE --geoip2-file=FILE     MaxMind GeoIP2 database file to use.
   -s SECTION --section=SECTION   Configuration section to use.
 
 Notes:
@@ -75,8 +76,8 @@ def has_intersections(db, nets, filename, owner):
         return True
 
 
-def has_restricted_ips(nets):
-    geo_loc_db = GeoLocDB()
+def has_restricted_ips(nets, geoip2_database=None):
+    geo_loc_db = GeoLocDB(database_path=geoip2_database)
     restricted_dict = defaultdict(lambda: IPSet())
     for ip in nets:
         country = geo_loc_db.check_restricted_ip(ip)
@@ -116,7 +117,7 @@ def import_request(db, request, source, force=False, init_stage=None):
         request["init_stage"] = init_stage
     if has_intersections(db, nets, source, owner):
         return False
-    if has_restricted_ips(nets):
+    if has_restricted_ips(nets, geoip2_database=args["--geoip2-file"]):
         # This is not combined with the previous check so the output
         # from each function can be seen so the user can get all messages
         # without multiple runs

--- a/bin/cyhy-import
+++ b/bin/cyhy-import
@@ -171,7 +171,7 @@ def import_stdin(db, force, init_stage=None):
 
 
 def main():
-    args = docopt(__doc__, version="v1.0.0")
+    args = docopt(__doc__, version="v1.0.1")
     db = database.db_from_config(args["--section"])
 
     if args["FILE"] != None:

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -535,7 +535,7 @@ def setstage(db, stage, cidrs):
 
 
 def main():
-    args = docopt(__doc__, version="v1.0.0")
+    args = docopt(__doc__, version="v1.0.1")
 
     db = database.db_from_config(args["--section"])
 

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -16,6 +16,7 @@ Options:
   --version                      Show version.
 
   -f FILENAME --file=FILENAME    Read addresses from a file.
+  -g FILE --geoip2-file=FILE     MaxMind GeoIP2 database file to use.
   -s SECTION --section=SECTION   Configuration section to use.
 
 Notes:
@@ -205,14 +206,14 @@ def do_list_all(db):
     print_cidrs(default_owner_ip_set, indent=1)
 
 
-def add(db, owner, cidrs):
+def add(db, owner, cidrs, geoip2_database=None):
     if owner == DEFAULT_OWNER:
         print "Cannot continue!\nNot allowed to add addresses to the default owner (%s)." % DEFAULT_OWNER
         sys.exit(-1)
 
     # Intersections with IPs owned by any owner other than the default owner
     intersections = db.RequestDoc.get_all_intersections(cidrs)
-    geo_loc_db = GeoLocDB()
+    geo_loc_db = GeoLocDB(database_path=geoip2_database)
     restricted_dict = defaultdict(lambda: IPSet())
     for ip in cidrs:
         country = geo_loc_db.check_restricted_ip(ip)
@@ -559,7 +560,7 @@ def main():
         print "# %d" % len(nets)
         print_cidrs(nets, indent=0)
     elif args["add"]:
-        add(db, args["OWNER"], nets)
+        add(db, args["OWNER"], nets, geoip2_database=args["--geoip2-file"])
     elif args["remove"]:
         wrapped_remove(db, args["OWNER"], nets)
     elif args["compare"]:

--- a/bin/cyhy-tool
+++ b/bin/cyhy-tool
@@ -204,7 +204,7 @@ def retire(db, owner):
 
 
 def main():
-    args = docopt(__doc__, version="v0.0.1")
+    args = docopt(__doc__, version="v1.0.0")
 
     config = Config(args["--section"])
     if config.config_created:

--- a/bin/cyhy-tool
+++ b/bin/cyhy-tool
@@ -17,6 +17,7 @@ Options:
   --version                      Show version.
   
   -f --foreground                Build indices in the foreground
+  -g FILE --geoip2-file=FILE     MaxMind GeoIP2 database file to use.
   -q --quiet                     Do not display progress bars
   -S --sync                      Update tally counts by scanning database
   -s SECTION --section=SECTION   Configuration section to use.
@@ -68,7 +69,7 @@ PB_RESET_WIDGETS = [
 ]
 
 
-def init_scan(db, owner, quiet=False):
+def init_scan(db, owner, quiet=False, geoip2_database=None):
     request = db.RequestDoc.get_by_owner(owner)
     if not request:
         print >> sys.stderr, 'No request with "%s" found.' % owner
@@ -94,7 +95,7 @@ def init_scan(db, owner, quiet=False):
     tally["_id"] = owner_id
     tally.save()
 
-    geo_loc_db = GeoLocDB()
+    geo_loc_db = GeoLocDB(database_path=geoip2_database)
     nets = request.networks
     pbar = pb.ProgressBar(
         widgets=PB_INIT_WIDGETS if not quiet else [], maxval=len(nets)
@@ -221,7 +222,7 @@ def main():
         database.ensure_indices(db, args["--foreground"])
     elif args["init"]:
         for i in args["OWNER"]:
-            init_scan(db, i, quiet=args["--quiet"])
+            init_scan(db, i, quiet=args["--quiet"], geoip2_database=args["--geoip2-file"])
     elif args["purge-running"]:
         if not util.warn_and_confirm(
             "Make sure ALL running jobs on scanners were stopped and processed by commander before continuing! See CYHY-287 for details."

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -7,7 +7,7 @@ import geoip2.database
 from geoip2.errors import AddressNotFoundError
 
 GEODB_FILES = ["GeoIP2-City.mmdb", "GeoLite2-City.mmdb"]
-GEODB_CITY_PATHS = ["/usr/share/GeoIP/", "/usr/local/share/GeoIP/"]
+GEODB_DIRECTORIES = ["/usr/share/GeoIP/", "/usr/local/share/GeoIP/"]
 GEODB_FILE_PATHS = []
 
 # The list of restricted countries was provided by CISA International Affairs
@@ -45,7 +45,7 @@ RESTRICTED_COUNTRIES = [
 
 # Ensure that the order in GEODB_FILES is used for searching
 for file in GEODB_FILES:
-    for path in GEODB_CITY_PATHS:
+    for path in GEODB_DIRECTORIES:
         GEODB_FILE_PATHS.append(path + file)
 
 

--- a/cyhy/core/geoloc.py
+++ b/cyhy/core/geoloc.py
@@ -58,7 +58,7 @@ class GeoLocDB(object):
                     break
             else:
                 raise Exception(
-                    "No GeoIP databases found.  Search in:", GEODB_CITY_PATHS
+                    "No GeoIP databases found.  Search in:", GEODB_FILE_PATHS
                 )
         self.__reader = geoip2.database.Reader(database_path)
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates any `cyhy-*` scripts that use the MaxMind GeoIP2 database to support specifying the path to the database as an option and the calls to `GeoLocDB()` are updated accordingly. It also updates a variable name to be more consistent and useful. 
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

While working on containerizing this project I realized it would be beneficial to be able to specify the location of the GeoIP2 database in commands.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

TBD.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

