### PR TITLE
Ensure console scripts are blackened

### DIFF
--- a/bin/cyhy-archive
+++ b/bin/cyhy-archive
@@ -171,7 +171,9 @@ def archive_and_delete(db, curr_date, archive_dir, parsed_db_uri):
                 mongodump_command += ["--authenticationDatabase={}".format(auth_db)]
 
             p = subprocess.Popen(
-                mongodump_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                mongodump_command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
             logger.info(
                 "{}: exporting documents older than {} to {}".format(
@@ -245,13 +247,15 @@ def archive_and_delete(db, curr_date, archive_dir, parsed_db_uri):
             ).count()
             logger.info(
                 "{}: {:,} documents exist after archiving".format(
-                    collection_name, doc_counts["post-archiving"][collection_name],
+                    collection_name,
+                    doc_counts["post-archiving"][collection_name],
                 )
             )
         else:  # no documents to archive
             logger.warning(
                 "{}: no documents are old enough to be archived (cutoff date: {})".format(
-                    collection_name, cutoff_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    collection_name,
+                    cutoff_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 )
             )
             results["exported_counts"][collection_name] = results["deleted_counts"][
@@ -307,7 +311,8 @@ def main():
             collection_name = db[collection_info["name"]].collection.name
             logger.fatal(
                 "  {}: exported {:,} documents".format(
-                    collection_name, results["exported_counts"].get(collection_name, 0),
+                    collection_name,
+                    results["exported_counts"].get(collection_name, 0),
                 )
             )
         if not args["--no-commander-pause"]:
@@ -323,12 +328,14 @@ def main():
             collection_name = db[collection_info["name"]].collection.name
             logger.fatal(
                 "  {}: exported {:,} documents".format(
-                    collection_name, results["exported_counts"].get(collection_name, 0),
+                    collection_name,
+                    results["exported_counts"].get(collection_name, 0),
                 )
             )
             logger.fatal(
                 "  {}: deleted {:,} documents".format(
-                    collection_name, results["deleted_counts"].get(collection_name, 0),
+                    collection_name,
+                    results["deleted_counts"].get(collection_name, 0),
                 )
             )
 

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -47,19 +47,15 @@ def read_file(filename):
 def do_list(db, owner):
     request = db.RequestDoc.get_by_owner(owner)
     for h in request.get("hostnames", []):
-        print(h)
+        print (h)
 
 
 def do_list_all(db):
     requests = db.RequestDoc.find({"hostnames": {"$exists": True}}).sort("_id")
     for r in requests:
-        print "# %s (%s): %d" % (
-            r["agency"]["name"],
-            r["_id"],
-            len(r["hostnames"])
-        )
+        print "# %s (%s): %d" % (r["agency"]["name"], r["_id"], len(r["hostnames"]))
         for h in sorted(r["hostnames"]):
-            print("\t%s" % h)
+            print ("\t%s" % h)
         print
 
 
@@ -75,7 +71,7 @@ def get_ipv4_addresses(hostname):
     """Return a set of IPv4 addresses for the given hostname."""
     ip_set = set()
     try:
-        answers = resolver.query(hostname, 'A')
+        answers = resolver.query(hostname, "A")
     # Could not resolve domain name
     except resolver.NoNameservers as e:
         print "Warning: No nameservers available to resolve %s" % hostname
@@ -125,10 +121,14 @@ def add(db, owner, domains, disallow_owned_ips):
                 existing_hostdoc = db.HostDoc.get_by_ip(ip)
                 if existing_hostdoc and existing_hostdoc["owner"] != DEFAULT_OWNER:
                     domain_problem = True
-                    print "ERROR - %s resolves to IP %s owned by %s in CyHy" % (d, ip, existing_hostdoc["owner"])
+                    print "ERROR - %s resolves to IP %s owned by %s in CyHy" % (
+                        d,
+                        ip,
+                        existing_hostdoc["owner"],
+                    )
                     resolves_to_owned_ip_domains.append(d)
                     break
-    
+
     if domain_problem:
         print "\n=== Summary of domain errors ==="
         if owned_domains:
@@ -155,7 +155,7 @@ def add(db, owner, domains, disallow_owned_ips):
 
     print "Domains added to %s (%s):" % (request["agency"]["name"], owner)
     for d in domains:
-        print("\t%s" % d)
+        print ("\t%s" % d)
 
 
 def remove(db, owner, domains):
@@ -168,10 +168,11 @@ def remove(db, owner, domains):
 
     if unowned_domains:
         print "ERROR - %s (%s) does not own the following domains:" % (
-            request["agency"]["name"], owner
+            request["agency"]["name"],
+            owner,
         )
         for d in sorted(unowned_domains):
-            print("\t%s" % d)
+            print ("\t%s" % d)
         sys.exit(-1)
 
     for d in domains:
@@ -180,7 +181,7 @@ def remove(db, owner, domains):
 
     print "Domains removed from %s (%s):" % (request["agency"]["name"], owner)
     for d in domains:
-        print("\t%s" % d)
+        print ("\t%s" % d)
 
     # Remove domains from any HostDocs that have them
     for d in domains:
@@ -195,9 +196,7 @@ def remove(db, owner, domains):
     # Close open tickets referencing the removed domains
     ticket_closing_time = util.utcnow()
     count = 0
-    for t in db.TicketDoc.find(
-        {"hostname": {"$in": domains}, "open": True}
-    ):
+    for t in db.TicketDoc.find({"hostname": {"$in": domains}, "open": True}):
         t["open"] = False
         t["time_closed"] = ticket_closing_time
         t.add_event(
@@ -207,6 +206,7 @@ def remove(db, owner, domains):
         count += 1
     print "Closed %d open tickets referencing removed domain(s)" % count
 
+
 def check(db, domains):
     domain_owners = get_existing_domains_and_owners(db)
     matched_domains = {}
@@ -214,22 +214,24 @@ def check(db, domains):
 
     for d in domains:
         if d in domain_owners:
-            matched_domains[domain_owners[d]] = matched_domains.get(domain_owners[d], []) + [d]
+            matched_domains[domain_owners[d]] = matched_domains.get(
+                domain_owners[d], []
+            ) + [d]
         else:
             unmatched_domains.append(d)
-    
+
     if matched_domains:
         for owner in sorted(matched_domains):
             domains = matched_domains[owner]
             print "# %s: %s" % (owner, len(domains))
             for d in sorted(domains):
-                print("\t%s" % d)
+                print ("\t%s" % d)
             print
 
     if unmatched_domains:
         print "# Unmatched: %s" % len(unmatched_domains)
         for d in sorted(unmatched_domains):
-            print("\t%s" % d)
+            print ("\t%s" % d)
 
 
 def change_ticket_owner(db, orig_owner, new_owner, reason, domains):
@@ -251,7 +253,7 @@ def change_ticket_owner(db, orig_owner, new_owner, reason, domains):
     print "%d tickets documents modified (%s -> %s)" % (
         result["nModified"],
         orig_owner,
-        new_owner
+        new_owner,
     )
 
 
@@ -274,10 +276,10 @@ def move(db, orig_owner, new_owner, domains_to_move):
     if domains_not_in_orig_owner:
         print "\nERROR - The following domains are NOT owned by %s (%s):" % (
             orig_owner,
-            orig_owner_request["agency"]["name"]
+            orig_owner_request["agency"]["name"],
         )
         for d in domains_not_in_orig_owner:
-            print("\t%s" % d)
+            print ("\t%s" % d)
         print "\nEXITING without making any changes."
         sys.exit(-1)
 
@@ -287,9 +289,7 @@ def move(db, orig_owner, new_owner, domains_to_move):
     )
 
     # Remove the domains_to_move from orig_owner's request doc
-    orig_owner_request["hostnames"] = sorted(
-        orig_owner_domains - set(domains_to_move)
-    )
+    orig_owner_request["hostnames"] = sorted(orig_owner_domains - set(domains_to_move))
     # Add the domains_to_move to new_owner's request doc
     new_owner_request["hostnames"] = sorted(
         set(new_owner_request.get("hostnames")) | set(domains_to_move)
@@ -302,11 +302,13 @@ def move(db, orig_owner, new_owner, domains_to_move):
     print "%s request document updated\n" % new_owner
 
     print "Domains moved from %s (%s) to %s (%s):" % (
-        orig_owner_request["agency"]["name"], orig_owner,
-        new_owner_request["agency"]["name"], new_owner
-        )
+        orig_owner_request["agency"]["name"],
+        orig_owner,
+        new_owner_request["agency"]["name"],
+        new_owner,
+    )
     for d in sorted(domains_to_move):
-        print("\t%s" % d)
+        print ("\t%s" % d)
 
 
 def main():
@@ -322,7 +324,7 @@ def main():
         if not db.RequestDoc.get_by_owner(args["OWNER"]):
             print "ERROR: Organization %s not found in DB" % args["OWNER"]
             sys.exit(-1)
-    
+
     if args.get("NEW_OWNER"):
         if not db.RequestDoc.get_by_owner(args["NEW_OWNER"]):
             print "ERROR: Organization %s not found in DB" % args["NEW_OWNER"]
@@ -338,14 +340,16 @@ def main():
         valid_domains.update(f_valid_domains)
         invalid_domains.update(f_invalid_domains)
     elif len(valid_domains) == 0:
-        stdin_valid_domains, stdin_invalid_domains = util.parse_domains(sys.stdin.readlines())
+        stdin_valid_domains, stdin_invalid_domains = util.parse_domains(
+            sys.stdin.readlines()
+        )
         valid_domains.update(stdin_valid_domains)
         invalid_domains.update(stdin_invalid_domains)
-    
+
     if invalid_domains:
         print "ERROR - Invalid domain(s):"
         for d in sorted(invalid_domains):
-            print(d)
+            print (d)
         sys.exit(-1)
 
     domains = list(valid_domains)
@@ -359,6 +363,7 @@ def main():
     elif args["remove"]:
         remove(db, args["OWNER"], domains)
     sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -35,14 +35,15 @@ from cyhy.util import util
 
 def get_requests(db):
     """Yield each of the non-retired owners in the database."""
-    requests = db.RequestDoc.find(spec={"retired":False}, sort=[("_id", 1)])
+    requests = db.RequestDoc.find(spec={"retired": False}, sort=[("_id", 1)])
     for r in requests:
         yield r
+
 
 def get_ipv4_addresses(hostname):
     """Return a set of IPv4 addresses for the given hostname."""
     try:
-        answers = resolver.query(hostname, 'A')
+        answers = resolver.query(hostname, "A")
         ip_list = [IPAddress(answer.address) for answer in answers]
         return set(ip_list)
     # Could not resolve domain name
@@ -57,12 +58,16 @@ def get_ipv4_addresses(hostname):
         print("    " + str(e))
         return set()
     except resolver.YXDOMAIN:
-        print("    Warning: DNS YXDOMAIN (query name too long after DNAME substitution) for " + hostname)
+        print(
+            "    Warning: DNS YXDOMAIN (query name too long after DNAME substitution) for "
+            + hostname
+        )
         return set()
+
 
 def close_tickets(db, ip, hostname, reason):
     """Close all open tickets for the given IP address and hostname.
-    
+
     Returns the number of tickets closed."""
     now = util.utcnow()
     close_event = {
@@ -74,16 +79,16 @@ def close_tickets(db, ip, hostname, reason):
     result = db.TicketDoc.collection.update(
         {"ip_int": int(ip), "hostname": hostname, "open": True},
         # Force false_positive to False since the ticket is being closed
-        {"$set": {"false_positive": False, 
-                  "open": False, 
-                  "time_closed": now}, 
-        "$push": {"events": close_event}
+        {
+            "$set": {"false_positive": False, "open": False, "time_closed": now},
+            "$push": {"events": close_event},
         },
         multi=True,
         safe=True,
         upsert=False,
     )
     return result["nModified"]
+
 
 def main():
     args = docopt(__doc__, version="v1.0.4")
@@ -122,7 +127,11 @@ def main():
                 # Find all the HostDocs that have this domain name as a value in their hostnames dictionary
                 hostdocs = db.HostDoc.get_by_hostname(hostname)
 
-                print("  " + str(hostdocs.count()) + " HostDocs currently reference this hostname")
+                print(
+                    "  "
+                    + str(hostdocs.count())
+                    + " HostDocs currently reference this hostname"
+                )
 
                 ip_set = set()
                 try:
@@ -134,7 +143,9 @@ def main():
                 # we don't want to make any HostDoc or TicketDoc changes based
                 # on incomplete or invalid DNS results.
                 except resolver.NoNameservers as e:
-                    print("    Warning: No nameservers available to resolve " + hostname)
+                    print(
+                        "    Warning: No nameservers available to resolve " + hostname
+                    )
                     print(str(e))
                     dns_exceptions["NoNameservers"].append(
                         {"hostname": hostname, "owner": r["_id"]}
@@ -156,7 +167,9 @@ def main():
                     )
                     continue  # Skip to the next hostname
 
-                print("  " + str(len(ip_set)) + " IPv4 addresses found for this hostname")
+                print(
+                    "  " + str(len(ip_set)) + " IPv4 addresses found for this hostname"
+                )
                 if not ip_set:
                     unresolvable_hostnames.append(hostname)
 
@@ -170,7 +183,9 @@ def main():
                         host_doc = db.HostDoc()
                         location = geo_loc_db.lookup(ip)
                         host_doc.init(ip, default_owner, location, starting_stage)
-                        host_doc["hostnames"] = [{"hostname": hostname, "owner": r["_id"]}]
+                        host_doc["hostnames"] = [
+                            {"hostname": hostname, "owner": r["_id"]}
+                        ]
                         host_doc.save()
                         print("Created HostDoc owned by: " + default_owner)
                         continue
@@ -179,12 +194,15 @@ def main():
                         # that is owned by a non-default CyHy entity, skip this
                         # IP address
                         if args["--no-owned"] and host_doc["owner"] != default_owner:
-                            print("Skipping IP; --no-owned option enabled and found HostDoc owned by " + host_doc["owner"])
+                            print(
+                                "Skipping IP; --no-owned option enabled and found HostDoc owned by "
+                                + host_doc["owner"]
+                            )
                             continue
                         print("Found HostDoc owned by: " + host_doc["owner"])
 
                     # The HostDoc did exist, so add the request ID and domain to the list of owners
-                    
+
                     # HostDoc.hostnames is a list of dictionaries with the following keys: hostname, owner
                     # An example looks like this:
                     # "hostnames": [
@@ -201,13 +219,18 @@ def main():
                     for h in host_doc["hostnames"]:
                         if h["hostname"] == hostname:
                             if h["owner"] != r["_id"]:
-                                print("    Hostname owner updated in HostDoc (%s -> %s)" % (h["owner"], r["_id"]))
+                                print(
+                                    "    Hostname owner updated in HostDoc (%s -> %s)"
+                                    % (h["owner"], r["_id"])
+                                )
                                 h["owner"] = r["_id"]
                             break
                     else:
                         # If the hostname isn't already in the list, add it
-                        host_doc["hostnames"].append({"hostname": hostname, "owner": r["_id"]})
-                    
+                        host_doc["hostnames"].append(
+                            {"hostname": hostname, "owner": r["_id"]}
+                        )
+
                     # Save the HostDoc
                     host_doc.save()
 
@@ -216,36 +239,46 @@ def main():
                     # If the hostdoc ip is not in the ip_set, remove the domain from the list of owners
                     if host.ip not in ip_set:
                         print("  Removing " + hostname + " from " + str(host.ip))
-                        host["hostnames"] = [i for i in host["hostnames"] if i["hostname"] != hostname]
+                        host["hostnames"] = [
+                            i for i in host["hostnames"] if i["hostname"] != hostname
+                        ]
                         host.save()
- 
-                        # Close all open tickets with this ip and hostname
-                        closed_count = close_tickets(db, host.ip, hostname, "Hostname no longer resolves to this IP address")
-                        print("  %d tickets documents closed for %s[%s]" % (
-                            closed_count,
-                            host.ip,
-                            hostname
-                        ))
 
-        # Find all the Default Owner HostDocs that don't have any hostnames, and 
+                        # Close all open tickets with this ip and hostname
+                        closed_count = close_tickets(
+                            db,
+                            host.ip,
+                            hostname,
+                            "Hostname no longer resolves to this IP address",
+                        )
+                        print(
+                            "  %d tickets documents closed for %s[%s]"
+                            % (closed_count, host.ip, hostname)
+                        )
+
+        # Find all the Default Owner HostDocs that don't have any hostnames, and
         # print out how many were deleted
         print("Deleting " + default_owner + " HostDocs that have no hostnames...")
-        result = db.HostDoc.collection.delete_many({"owner": default_owner, "hostnames": {"$size": 0}})
+        result = db.HostDoc.collection.delete_many(
+            {"owner": default_owner, "hostnames": {"$size": 0}}
+        )
 
         # Print out how many documents were deleted
         print("Deleted " + str(result.deleted_count) + " HostDocs")
-            
+
         # Synchronize the default owner's TallyDoc
         tally_doc = db.TallyDoc.get_by_owner(default_owner)
         if not tally_doc:
             tally_doc = db.TallyDoc()
-            tally_doc["_id"]= default_owner
+            tally_doc["_id"] = default_owner
             tally_doc.save()
         tally_doc.sync(db)
         print("Synchronized " + default_owner + " TallyDoc")
 
-        print("\nHostnames that do not resolve to any IPv4 addresses - %d occurrences" %
-              len(unresolvable_hostnames))
+        print(
+            "\nHostnames that do not resolve to any IPv4 addresses - %d occurrences"
+            % len(unresolvable_hostnames)
+        )
         print("(excludes DNS timeouts and unknown DNS exceptions):")
         for hostname in sorted(unresolvable_hostnames):
             print("  %s" % hostname)

--- a/bin/cyhy-ip
+++ b/bin/cyhy-ip
@@ -40,7 +40,6 @@ from cyhy.db import database, CHDatabase
 from cyhy.util import util
 
 
-
 def munge(x):
     """Munges a tuple or list of IPNetwork and IPRange objects into a single IPSet.
 
@@ -128,6 +127,7 @@ def get_special_intersections(cidrs):
             results[description] = intersection
     return results
 
+
 def print_intersections(intersections):
     for request, intersecting_cidrs in intersections.iteritems():
         if type(request) == str:
@@ -167,9 +167,8 @@ def check(db, cidrs):
 def get_default_owner_ip_set(db):
     # Return IPSet of all IP addresses owned by default owner
     default_owner_ips = [
-        IPAddress(h["_id"]) for h in db.HostDoc.find(
-            {"owner": DEFAULT_OWNER}, {"_id": 1}
-        )
+        IPAddress(h["_id"])
+        for h in db.HostDoc.find({"owner": DEFAULT_OWNER}, {"_id": 1})
     ]
     return IPSet(default_owner_ips)
 
@@ -188,14 +187,15 @@ def do_list(db, owner):
             print i
 
 
-
 def do_list_all(db):
     # Intersections with IPs owned by any owner other than the default owner
     intersections = db.RequestDoc.get_all_intersections(IPSet(["0.0.0.0/0"]))
     print_intersections(intersections)
 
     # List default owner CIDRs
-    default_owner_name = db.RequestDoc.find_one({"_id": DEFAULT_OWNER})["agency"]["name"]
+    default_owner_name = db.RequestDoc.find_one({"_id": DEFAULT_OWNER})["agency"][
+        "name"
+    ]
     default_owner_ip_set = get_default_owner_ip_set(db)
     print "# %s (%s): %s" % (
         default_owner_name,
@@ -254,11 +254,18 @@ def add(db, owner, cidrs):
             # Update existing host document from default owner to new owner
             host = db.HostDoc.get_by_ip(ip)
             if not host:
-                print "ERROR: Host document for %s not found, even though it is owned by %s!" % (str(ip), DEFAULT_OWNER)
+                print "ERROR: Host document for %s not found, even though it is owned by %s!" % (
+                    str(ip),
+                    DEFAULT_OWNER,
+                )
                 sys.exit(-1)
             host["owner"] = owner
             host.save()
-            print "Warning: %s was owned by %s, now owned by %s." % (str(ip), DEFAULT_OWNER, owner)
+            print "Warning: %s was owned by %s, now owned by %s." % (
+                str(ip),
+                DEFAULT_OWNER,
+                owner,
+            )
             default_owner_modified = True
         else:
             # Create new host document
@@ -276,7 +283,10 @@ def add(db, owner, cidrs):
         default_owner_tally = db.TallyDoc.get_by_owner(DEFAULT_OWNER)
         default_owner_tally.sync(db)
         print "Default owner (%s) IPs modified and tally synchronized." % DEFAULT_OWNER
-    print "IPs added to %s request and initialized.  Tally sync for %s required to start scan of new IPs." % (owner, owner)
+    print "IPs added to %s request and initialized.  Tally sync for %s required to start scan of new IPs." % (
+        owner,
+        owner,
+    )
     sys.exit(0)
 
 
@@ -470,7 +480,7 @@ def move(db, orig_owner, new_owner, networks_to_move):
 
 def setstage(db, stage, cidrs):
     # intersections with IPs owned by any owner other than the default owner
-    intersections = db.RequestDoc.get_all_intersections(cidrs)  
+    intersections = db.RequestDoc.get_all_intersections(cidrs)
     # intersections with IPs owned by the default owner
     intersections.update(get_default_owner_intersections(db, cidrs))
     matched = IPSet()

--- a/bin/cyhy-kevsync
+++ b/bin/cyhy-kevsync
@@ -67,8 +67,10 @@ def parse_json(db, json_stream):
         entry_doc.save(safe=False)
 
     all_cve_ids = set(i["_id"] for i in kevs)
-    print("Imported %d KEV entries, %d are known ransomware." % (
-        len(all_cve_ids), known_ransomware_count))
+    print(
+        "Imported %d KEV entries, %d are known ransomware."
+        % (len(all_cve_ids), known_ransomware_count)
+    )
     if data.get("count"):
         if data["count"] != len(all_cve_ids):
             print(

--- a/bin/cyhy-mongo
+++ b/bin/cyhy-mongo
@@ -32,16 +32,13 @@ def main():
     config = Config(args["SECTION"])
     p = RE.match(config.db_uri).groupdict()
     if p["username"] and p["password"]:
-        cmd = (
-            "mongo --host %s --port %s --authenticationDatabase %s -u %s --password=%s %s"
-            % (
-                p["hostname"],
-                p["port"],
-                p["path"],
-                p["username"],
-                p["password"],
-                config.db_name,
-            )
+        cmd = "mongo --host %s --port %s --authenticationDatabase %s -u %s --password=%s %s" % (
+            p["hostname"],
+            p["port"],
+            p["path"],
+            p["username"],
+            p["password"],
+            config.db_name,
         )
     else:
         cmd = "mongo --host %s --port %s --authenticationDatabase %s %s" % (

--- a/bin/cyhy-nvdsync
+++ b/bin/cyhy-nvdsync
@@ -50,12 +50,14 @@ def parse_json(db, json_stream):
             continue
 
         # Reject CVEs that don't have V2 or V3 CVSS data
-        if not any(k in entry["cve"].get("metrics", {})
+        if not any(
+            k in entry["cve"].get("metrics", {})
             for k in [
                 "cvssMetricV2",
                 "cvssMetricV30",
                 "cvssMetricV31",
-            ]):
+            ]
+        ):
             # Make sure they are removed from our db.
             db.CVEDoc.collection.remove({"_id": cve_id}, safe=False)
             print "x",
@@ -85,11 +87,13 @@ def parse_json(db, json_stream):
 
             print ".",
             # Upsert CVE document in the database
-            entry_doc = db.CVEDoc({
-                "_id": cve_id,
-                "cvss_score": float(cvss_base_score),
-                "cvss_version": cvss_version
-            })
+            entry_doc = db.CVEDoc(
+                {
+                    "_id": cve_id,
+                    "cvss_score": float(cvss_base_score),
+                    "cvss_version": cvss_version,
+                }
+            )
             entry_doc.save(safe=False)
     print "\n\n"
 

--- a/bin/cyhy-tool
+++ b/bin/cyhy-tool
@@ -262,9 +262,7 @@ def main():
 
         for orgId in orgIds:
             retire(db, orgId)
-        print str(
-            orgIds
-        ) + " have been successfully retired."
+        print str(orgIds) + " have been successfully retired."
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request ensures that all console scripts in the `bin/` sub-directory have been formatted by `black`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is related to the work in https://github.com/cisagov/action-blacken-python2/pull/13 as I noticed that the console scripts in the `bin/` sub-directory were not being checked. This gets these scripts into an "initially good" state so that they are not picked up needlessly in future pull requests.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

👀
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
