### PR TITLE
Update the label configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -44,6 +44,14 @@ python:
   - changed-files:
       - any-glob-to-any-file:
           - "**/*.py"
+shell script:
+  - changed-files:
+      - any-glob-to-any-file:
+          # If this project has any shell scripts that do not end in the ".sh"
+          # extension, add them below.
+          - "**/*.sh"
+          - bump-version
+          - setup-env
 terraform:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -50,8 +50,8 @@ shell script:
           # If this project has any shell scripts that do not end in the ".sh"
           # extension, add them below.
           - "**/*.sh"
-          - bump-version
-          - setup-env
+          - var/getenv
+          - var/getopsenv
 terraform:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,7 +2,7 @@
 # Rather than breaking up descriptions into multiline strings we disable that
 # specific rule in yamllint for this file.
 # yamllint disable rule:line-length
-- color: f15a53
+- color: ff5850
   description: Pull requests that update Ansible code
   name: ansible
 - color: eb6420
@@ -20,7 +20,7 @@
 - color: 0366d6
   description: Pull requests that update a dependency file
   name: dependencies
-- color: 2497ed
+- color: 1d63ed
   description: Pull requests that update Docker code
   name: docker
 - color: 5319e7
@@ -47,7 +47,7 @@
 - color: fef2c0
   description: This issue or pull request is not applicable, incorrect, or obsolete
   name: invalid
-- color: f1d642
+- color: f0db4f
   description: Pull requests that update JavaScript code
   name: javascript
 - color: ce099a
@@ -62,7 +62,7 @@
 - color: 02a8ef
   description: Pull requests that update Packer code
   name: packer
-- color: 3772a4
+- color: 3776ab
   description: Pull requests that update Python code
   name: python
 - color: ef476c
@@ -71,13 +71,16 @@
 - color: d73a4a
   description: This issue or pull request addresses a security issue
   name: security
+- color: 4eaa25
+  description: Pull requests that update shell scripts
+  name: shell script
 - color: 7b42bc
   description: Pull requests that update Terraform code
   name: terraform
 - color: 00008b
   description: This issue or pull request adds or otherwise modifies test code
   name: test
-- color: 2b6ebf
+- color: 2678c5
   description: Pull requests that update TypeScript code
   name: typescript
 - color: 1d76db

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -2,11 +2,9 @@
 name: Label pull requests
 
 on:  # yamllint disable-line rule:truthy
+  # We use the default activity types for the pull_request event as specified here:
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
   pull_request:
-    types:
-      - edited
-      - opened
-      - synchronize
 
 # Set a default shell for any run steps. The `-Eueo pipefail` sets errtrace,
 # nounset, errexit, and pipefail. The `-x` will print all commands as they are
@@ -59,7 +57,6 @@ jobs:
     permissions:
       # Permissions required by actions/labeler
       contents: read
-      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -84,7 +84,7 @@ jobs:
           # monitoring configuration *does not* require you to modify
           # this workflow.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Sync repository labels
         if: success()
         uses: crazy-max/ghaction-github-labeler@v5


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request pulls in the latest versions of the `labeler.yml` and `sync-labels.yml` workflows from [cisagov/skeleton-generic](https://github.com/cisagov/skeleton-generic) and their respective configuration files.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We need to keep these files up-to-date manually so here we are!
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

👀
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
