### PR TITLE
Add index to speed up query in `cisagov/gatherer`

### DIFF
--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -730,7 +730,7 @@ class PortScanDoc(ScanDoc):
     def get_indices(self):
         super_indices = super(PortScanDoc, self).get_indices()
         return super_indices + (
-            # This query is added with the intent of speeding up this
+            # This index is added with the intent of speeding up this
             # query:
             # https://github.com/cisagov/gatherer/blob/12357f594e534a2d02432e8255c4a7e5cb58dd1c/src/fed_hostnames.py#L125-L137
             (

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -730,6 +730,15 @@ class PortScanDoc(ScanDoc):
     def get_indices(self):
         super_indices = super(PortScanDoc, self).get_indices()
         return super_indices + (
+            # This query is added with the intent of speeding up this
+            # query:
+            # https://github.com/cisagov/gatherer/blob/12357f594e534a2d02432e8255c4a7e5cb58dd1c/src/fed_hostnames.py#L125-L137
+            (
+                "latest_owner_port",
+                [("latest", 1), ("owner", 1), ("port", 1)],
+                False,
+                False,
+            ),
             (
                 "latest_owner_state",
                 [("latest", 1), ("owner", 1), ("state", 1)],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.3.0",
+    version="1.3.1",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds an index to help speed up a [`cisagov/gatherer` query](https://github.com/cisagov/gatherer/blob/12357f594e534a2d02432e8255c4a7e5cb58dd1c/src/fed_hostnames.py#L125-L137).

## 💭 Motivation and context ##

While debugging a separate issue @dav3r found that this query currently takes over 30 minutes to run, so it is worth adding an index to speed it up.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release (necessary if and only if the version was bumped).
- [x] Plan a time to build this index in Production.
