### PR TITLE
Add cleanup function in `load_places.sh` and update `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,20 @@
+# This file specifies intentionally untracked files that Git should ignore.
+# Files already tracked by Git are not affected.
+# See: https://git-scm.com/docs/gitignore
+
+## MacOS ##
+.DS_Store
+
+# Project Specific
+.dbshell
+.mongorc.js
+*.tgz
+test-data
+
+## Python ##
+__pycache__
+.ipynb_checkpoints
+.pytest_cache
+.python-version
 *.egg-info
 *.pyc
-*.tgz
-._*
-.DS_Store
-.ipynb_checkpoints
-.python-version

--- a/var/load_places.sh
+++ b/var/load_places.sh
@@ -47,7 +47,10 @@ function cleanup() {
 	# Remove temporary places directory and exit with the provided exit code.
 	local exit_code="${1-0}"
 	if [ -d "${TMP_PLACES_DIR}" ]; then
-		rm --recursive "${TMP_PLACES_DIR}" || true
+		# Use the short -R option rather than the long --recursive option
+		# because the long option is not supported on all platforms (e.g.
+		# macOS).
+		rm -R "${TMP_PLACES_DIR}" || true
 	fi
 	return "${exit_code}"
 }

--- a/var/load_places.sh
+++ b/var/load_places.sh
@@ -43,6 +43,18 @@ DATA_BASE_URL="https://prd-tnm.s3.amazonaws.com/StagedProducts/GeographicNames/A
 TMP_PLACES_DIR="/tmp/places"
 ADDL_PLACES_FILE="../extras/ADDL_CYHY_PLACES.txt"
 
+function cleanup() {
+	# Remove temporary places directory and exit with the provided exit code.
+	local exit_code="${1-0}"
+	if [ -d "${TMP_PLACES_DIR}" ]; then
+		rm --recursive "${TMP_PLACES_DIR}" || true
+	fi
+	return "${exit_code}"
+}
+
+# Set up a trap to clean things up on exit, regardless of success or failure.
+trap 'cleanup "$?"' EXIT
+
 # Create and change to temporary working directory.
 mkdir -p ${TMP_PLACES_DIR}
 cd ${TMP_PLACES_DIR}
@@ -73,6 +85,3 @@ else
 	"${SCRIPT_DIR}/GNIS_data_import.py" -s "${DB_SECTION}" \
 		"${SCRIPT_DIR}/${ADDL_PLACES_FILE}"
 fi
-
-# clean up
-rm -R ${TMP_PLACES_DIR}


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request improves the `var/load_places.sh` script by making its cleanup process more robust and reliable. The main change is the introduction of a `cleanup` function that ensures the temporary directory is always removed, even if the script exits due to an error.

This PR also adds some additional file and directory patterns to the `.gitignore` file.

**Reliability and maintainability improvements:**

* Added a `cleanup` function that removes the temporary places directory and exits with the correct status code, ensuring resources are cleaned up properly.
* Set a `trap` to call the `cleanup` function on script exit, guaranteeing cleanup occurs regardless of whether the script succeeds or fails.
* Removed the previous manual cleanup command at the end of the script, as cleanup is now handled automatically.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

For the cleanup change in `load_places.sh`, I was recently rebuilding the MongoDB/commander AMI in `cyhy_amis` and encountered a situation where `load_places.sh` ran unsuccessfully and the "places" zip file was not deleted.  So on the subsequent run, `unzip` got hung up prompting the user about whether or not to overwrite that zip file.  The change in this PR prevents that situation by automatically deleting the places directory regardless of whether the script fails or not, which is our preferred behavior.

As for updating `.gitignore`, I had a bunch of local files that seemed like good candidates to be ignored by git so I added them in this PR.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I locally tested the changes to `load_places.sh` and confirmed that the new `cleanup` function is called prior to the conclusion of the script and that it does indeed delete the temporary directory.

The changes to `.gitignore` were visually verified by me.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

