### PR TITLE
Add `compare` option to `cyhy domain`

### DIFF
--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -2,7 +2,7 @@
 """Manage domain assignments to owners.
 
 Usage:
-  cyhy-domain [options] (add | remove) OWNER [DOMAINS ...]
+  cyhy-domain [options] (add | compare | remove) OWNER [DOMAINS ...]
   cyhy-domain [options] check [DOMAINS ...]
   cyhy-domain [options] list OWNER
   cyhy-domain [options] list-all
@@ -234,6 +234,45 @@ def check(db, domains):
             print ("\t%s" % d)
 
 
+def compare(db, owner, new_domains):
+    request = db.RequestDoc.get_by_owner(owner)
+    old_domain_set = set(request.get("hostnames", []))
+    new_domain_set = set(new_domains)
+
+    added = new_domain_set - old_domain_set
+    removed = old_domain_set - new_domain_set
+    unchanged = old_domain_set & new_domain_set
+
+    print "New Domains (%s domains)" % ("{:,}".format(len(new_domain_set)))
+    for d in sorted(new_domain_set):
+        print d
+
+    print
+    print "Previous Domains (%s domains)" % ("{:,}".format(len(old_domain_set)))
+    for d in sorted(old_domain_set):
+        print d
+
+    print
+    print "Unchanged Domains (%s domains)" % ("{:,}".format(len(unchanged)))
+    for d in sorted(unchanged):
+        print d
+
+    print
+    print "Added Domains (%s domains)" % ("{:,}".format(len(added)))
+    for d in sorted(added):
+        print d
+
+    print
+    print "Removed Domains (%s domains)" % ("{:,}".format(len(removed)))
+    for d in sorted(removed):
+        print d
+
+    print
+    print "Net domain count change: %s" % (
+        "{:,}".format(len(new_domain_set) - len(old_domain_set))
+    )
+
+
 def change_ticket_owner(db, orig_owner, new_owner, reason, domains):
     change_event = {
         "time": util.utcnow(),
@@ -358,6 +397,8 @@ def main():
         add(db, args["OWNER"], domains, args["--no-owned"])
     elif args["check"]:
         check(db, domains)
+    elif args["compare"]:
+        compare(db, args["OWNER"], domains)
     elif args["move"]:
         move(db, args["OWNER"], args["NEW_OWNER"], domains)
     elif args["remove"]:

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -351,7 +351,7 @@ def move(db, orig_owner, new_owner, domains_to_move):
 
 
 def main():
-    args = docopt(__doc__, version="v1.2.0")
+    args = docopt(__doc__, version="v1.3.0")
 
     db = database.db_from_config(args["--section"], args["--config-file"])
 


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a `compare` command to `cyhy-domain`, mirroring the existing `compare` feature in `cyhy-ip`. It lets an operator preview how a proposed domain list differs from what an owner currently has assigned in CyHy, without making any changes to the database.

Given an `OWNER` and a set of domains (from the command line, a file, or stdin), the command reports:

- **New Domains** – the full proposed domain list
- **Previous Domains** – the domains currently assigned to the owner
- **Unchanged Domains** – domains present in both lists
- **Added Domains** – domains in the new list, but not currently assigned
- **Removed Domains** – domains currently assigned, but not in the new list
- **Net domain count change** – the difference in total domain count

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Functionality similar to `cyhy-ip compare` was requested in #156.

Resolves #156.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested the new `compare` feature and it outputs domain information in the expected manner.

- Ran `cyhy-domain compare OWNER ...` against a sample owner with:
  - domains added only
  - domains removed only
  - a mix of added, removed, and unchanged domains
  - an empty proposed list
- Confirmed each section (New / Previous / Unchanged / Added / Removed) and the net count change are correct

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
