### PR TITLE
Refactor `RequestDoc` functions (`get_all_descendants` and  `get_owner_to_type_dict`) to improve performance

### DIFF
--- a/cyhy/__init__.py
+++ b/cyhy/__init__.py
@@ -6,7 +6,7 @@ __path__ = extend_path(__path__, __name__)
 import sys as _sys
 
 #: Version info (major, minor, maintenance, status)
-VERSION = (1, 3, 1)
+VERSION = (1, 3, 2)
 STATUS = ""
 __version__ = "%d.%d.%d" % VERSION[0:3] + STATUS
 

--- a/cyhy/__init__.py
+++ b/cyhy/__init__.py
@@ -6,7 +6,7 @@ __path__ = extend_path(__path__, __name__)
 import sys as _sys
 
 #: Version info (major, minor, maintenance, status)
-VERSION = (1, 3, 0)
+VERSION = (1, 3, 1)
 STATUS = ""
 __version__ = "%d.%d.%d" % VERSION[0:3] + STATUS
 

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1294,52 +1294,81 @@ class RequestDoc(RootDoc):
         self["children"] = list(set(self["children"]) - set(child_ids))
         return True
 
+    def _load_org_info(self):
+        """Load relevant fields for every org into a dict keyed by _id.
+
+        Only the three fields needed for hierarchy traversal are fetched, and
+        the raw documents are read straight from the collection, which avoids
+        transferring large fields (e.g. networks, hostnames) and skips the
+        overhead of instantiating a full document per org.
+        """
+        org_info = dict()
+        for org in self.collection.find(
+            {}, {"children": 1, "stakeholder": 1, "retired": 1}
+        ):
+            org_info[org["_id"]] = org
+        return org_info
+
+    @staticmethod
+    def _descendants(org_info, owner, stakeholders_only=False, include_retired=False):
+        """Return the descendants of owner using a prebuilt org_info dict.
+
+        This is the pure in-memory traversal used by get_all_descendants().  It
+        is separated out so that callers which need descendants for many owners
+        (e.g. get_owner_to_type_dict) can build org_info once and reuse it.
+        """
+        if owner not in org_info:
+            raise ValueError(owner + " has no request document")
+
+        # Walk the hierarchy iteratively.  The "visited" set ensures every org
+        # is processed at most once, which prevents infinite loops on any
+        # cyclic data and avoids re-walking shared subtrees when an org is a
+        # child of more than one parent.  Note: retired orgs are pruned along
+        # with their entire subtree, while the stakeholder filter only affects
+        # membership (their children are still traversed).
+        descendants = set()
+        visited = set()
+        stack = list(org_info[owner].get("children", []))
+        while stack:
+            child = stack.pop()
+            if child in visited:
+                continue
+            visited.add(child)
+            info = org_info.get(child)
+            if info is None:
+                # Child references an org with no request document; skip it.
+                continue
+            if not include_retired and info.get("retired"):
+                continue
+            if not stakeholders_only or info.get("stakeholder"):
+                descendants.add(child)
+            stack.extend(info.get("children", []))
+        return list(descendants)
+
     def get_all_descendants(
         self, owner, stakeholders_only=False, include_retired=False
     ):
-        # Build dict of every org and its children (if any)
-        org_info = dict()
-        for org in self.find():
-            org_info[org["_id"]] = {
-                "children": org.get("children", []),
-                "stakeholder": org.get("stakeholder", False),
-                "retired": org.get("retired", False),
-            }
-
-        if not org_info.get(owner):
-            raise ValueError(owner + " has no request document")
-
-        def get_descendants(org_info, current_org, stakeholders_only, include_retired):
-            # Recursive function to get descendants of current_org
-            descendants = set()
-            for child_org in org_info.get(current_org, {}).get("children", []):
-                if include_retired or not org_info[child_org].get("retired"):
-                    if not stakeholders_only or org_info[child_org].get("stakeholder"):
-                        descendants.add(child_org)
-                    descendants = descendants.union(
-                        get_descendants(
-                            org_info, child_org, stakeholders_only, include_retired
-                        )
-                    )
-            return descendants
-
-        # Build descendants set
-        descendants = set()
-        descendants = descendants.union(
-            get_descendants(org_info, owner, stakeholders_only, include_retired)
+        return self._descendants(
+            self._load_org_info(), owner, stakeholders_only, include_retired
         )
-        return list(descendants)
 
     def get_owner_to_type_dict(self, stakeholders_only=False, include_retired=False):
-        """returns a dict of owner_id:type. "stakeholders_only" parameter eliminates non-stakeholders from the dict."""
+        """Return a dict of owner_id:type. 
+        
+        "stakeholders_only" determines whether non-stakeholders should be included.
+        "include_retired" determines whether retired owners should be included.
+        """
+        # Load org_info once and reuse it for every AGENCY_TYPE traversal
+        # instead of reloading the entire collection on each iteration.
+        org_info = self._load_org_info()
         types = defaultdict(lambda: list())
         for agency_type in AGENCY_TYPE:
-            all_agency_type_descendants = self.get_all_descendants(
-                agency_type, include_retired=include_retired
+            all_agency_type_descendants = self._descendants(
+                org_info, agency_type, include_retired=include_retired
             )
-            for org in self.find({"_id": {"$in": all_agency_type_descendants}}):
-                if not stakeholders_only or org["stakeholder"]:
-                    types[org["_id"]].append(agency_type)
+            for org_id in all_agency_type_descendants:
+                if not stakeholders_only or org_info[org_id].get("stakeholder"):
+                    types[org_id].append(agency_type)
 
         # Check for any orgs that fall into multiple types.  This can occur
         # under normal circumstances when using the CYHY_THIRD_PARTY report

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1323,12 +1323,14 @@ class RequestDoc(RootDoc):
         # Walk the hierarchy iteratively.  The "visited" set ensures every org
         # is processed at most once, which prevents infinite loops on any
         # cyclic data and avoids re-walking shared subtrees when an org is a
-        # child of more than one parent.  Note: retired orgs are pruned along
+        # child of more than one parent.  It is seeded with the owner so that a
+        # cycle pointing back at the owner (e.g. A -> B -> A) can never add the
+        # owner to its own descendants.  Note: retired orgs are pruned along
         # with their entire subtree, while the stakeholder filter only affects
         # membership (their children are still traversed).
         descendants = set()
-        visited = set()
-        stack = list(org_info[owner].get("children", []))
+        visited = set([owner])
+        stack = list(org_info[owner].get("children") or [])
         while stack:
             child = stack.pop()
             if child in visited:
@@ -1342,7 +1344,7 @@ class RequestDoc(RootDoc):
                 continue
             if not stakeholders_only or info.get("stakeholder"):
                 descendants.add(child)
-            stack.extend(info.get("children", []))
+            stack.extend(info.get("children") or [])
         return list(descendants)
 
     def get_all_descendants(

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1353,8 +1353,8 @@ class RequestDoc(RootDoc):
         )
 
     def get_owner_to_type_dict(self, stakeholders_only=False, include_retired=False):
-        """Return a dict of owner_id:type. 
-        
+        """Return a dict of owner_id:type.
+
         "stakeholders_only" determines whether non-stakeholders should be included.
         "include_retired" determines whether retired owners should be included.
         """

--- a/cyhy/test/test_request_hierarchy.py
+++ b/cyhy/test/test_request_hierarchy.py
@@ -120,16 +120,36 @@ _HIERARCHY_IDS = [
 
 _HIERARCHY_DOCS = [
     # ROOT -> A, B
-    {"_id": "TEST_ROOT", "children": ["TEST_A", "TEST_B"], "stakeholder": True, "retired": False},
+    {
+        "_id": "TEST_ROOT",
+        "children": ["TEST_A", "TEST_B"],
+        "stakeholder": True,
+        "retired": False,
+    },
     # A -> C
     {"_id": "TEST_A", "children": ["TEST_C"], "stakeholder": True, "retired": False},
     # B -> C (shared with A), B -> RETIRED (non-stakeholder parent)
-    {"_id": "TEST_B", "children": ["TEST_C", "TEST_RETIRED"], "stakeholder": False, "retired": False},
+    {
+        "_id": "TEST_B",
+        "children": ["TEST_C", "TEST_RETIRED"],
+        "stakeholder": False,
+        "retired": False,
+    },
     # C is a shared leaf
     {"_id": "TEST_C", "children": [], "stakeholder": True, "retired": False},
     # RETIRED prunes its subtree unless include_retired=True
-    {"_id": "TEST_RETIRED", "children": ["TEST_UNDER_RETIRED"], "stakeholder": True, "retired": True},
-    {"_id": "TEST_UNDER_RETIRED", "children": [], "stakeholder": True, "retired": False},
+    {
+        "_id": "TEST_RETIRED",
+        "children": ["TEST_UNDER_RETIRED"],
+        "stakeholder": True,
+        "retired": True,
+    },
+    {
+        "_id": "TEST_UNDER_RETIRED",
+        "children": [],
+        "stakeholder": True,
+        "retired": False,
+    },
 ]
 
 

--- a/cyhy/test/test_request_hierarchy.py
+++ b/cyhy/test/test_request_hierarchy.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env py.test -v
+
+# third-party libraries (install with pip)
+import pytest
+
+# local libraries
+from common_fixtures import database
+from cyhy.db.database import RequestDoc
+
+
+def make_org(_id, children=None, stakeholder=False, retired=False):
+    """Build a minimal org_info entry like _load_org_info() produces."""
+    return {
+        "_id": _id,
+        "children": children or [],
+        "retired": retired,
+        "stakeholder": stakeholder,
+    }
+
+
+def make_org_info(*orgs):
+    return {o["_id"]: o for o in orgs}
+
+
+class TestDescendantsTraversal:
+    """Unit tests for RequestDoc._descendants().
+
+    These exercise the pure in-memory hierarchy walk and require no database.
+    """
+
+    def test_owner_not_included_and_finds_all_levels(self):
+        # ROOT -> A -> B ; ROOT -> C
+        org_info = make_org_info(
+            make_org("ROOT", ["A", "C"]),
+            make_org("A", ["B"]),
+            make_org("B"),
+            make_org("C"),
+        )
+        result = RequestDoc._descendants(org_info, "ROOT")
+        assert sorted(result) == ["A", "B", "C"]
+        assert "ROOT" not in result  # owner itself is never a descendant
+
+    def test_leaf_owner_returns_empty(self):
+        org_info = make_org_info(make_org("LEAF"))
+        assert RequestDoc._descendants(org_info, "LEAF") == []
+
+    def test_unknown_owner_raises(self):
+        org_info = make_org_info(make_org("ROOT"))
+        with pytest.raises(ValueError):
+            RequestDoc._descendants(org_info, "NOPE")
+
+    def test_stakeholders_only_filters_membership_but_still_traverses(self):
+        # ROOT -> MID(non-stakeholder) -> LEAF(stakeholder)
+        # MID must be excluded from results, but LEAF must still be reached.
+        org_info = make_org_info(
+            make_org("ROOT", ["MID"], stakeholder=True),
+            make_org("MID", ["LEAF"], stakeholder=False),
+            make_org("LEAF", stakeholder=True),
+        )
+        result = RequestDoc._descendants(org_info, "ROOT", stakeholders_only=True)
+        assert sorted(result) == ["LEAF"]
+
+    def test_retired_prunes_entire_subtree_by_default(self):
+        # ROOT -> RETIRED -> LIVE_GRANDCHILD
+        # RETIRED and everything under it should be excluded.
+        org_info = make_org_info(
+            make_org("ROOT", ["RETIRED"]),
+            make_org("RETIRED", ["LIVE_GRANDCHILD"], retired=True),
+            make_org("LIVE_GRANDCHILD"),
+        )
+        assert RequestDoc._descendants(org_info, "ROOT") == []
+
+    def test_include_retired_includes_retired_and_subtree(self):
+        org_info = make_org_info(
+            make_org("ROOT", ["RETIRED"]),
+            make_org("RETIRED", ["GRANDCHILD"], retired=True),
+            make_org("GRANDCHILD"),
+        )
+        result = RequestDoc._descendants(org_info, "ROOT", include_retired=True)
+        assert sorted(result) == ["GRANDCHILD", "RETIRED"]
+
+    def test_shared_subtree_returns_no_duplicates(self):
+        # Both P1 and P2 are children of ROOT and both point at SHARED.
+        org_info = make_org_info(
+            make_org("ROOT", ["P1", "P2"]),
+            make_org("P1", ["SHARED"]),
+            make_org("P2", ["SHARED"]),
+            make_org("SHARED"),
+        )
+        result = RequestDoc._descendants(org_info, "ROOT")
+        assert sorted(result) == ["P1", "P2", "SHARED"]
+        assert len(result) == len(set(result))  # no dupes
+
+    def test_cycle_terminates(self):
+        # A -> B -> A ; must not infinite loop.
+        org_info = make_org_info(
+            make_org("A", ["B"]),
+            make_org("B", ["A"]),
+        )
+        result = RequestDoc._descendants(org_info, "A")
+        assert sorted(result) == ["A", "B"]
+
+    def test_dangling_child_reference_is_skipped(self):
+        # ROOT references GHOST which has no org document.
+        org_info = make_org_info(make_org("ROOT", ["GHOST", "REAL"]), make_org("REAL"))
+        result = RequestDoc._descendants(org_info, "ROOT")
+        assert sorted(result) == ["REAL"]
+
+
+# IDs used by the integration fixture below.  Prefixed so cleanup only touches
+# these documents and leaves any other request documents untouched.
+_HIERARCHY_IDS = [
+    "TEST_ROOT",
+    "TEST_A",
+    "TEST_B",
+    "TEST_C",
+    "TEST_RETIRED",
+    "TEST_UNDER_RETIRED",
+]
+
+_HIERARCHY_DOCS = [
+    # ROOT -> A, B
+    {"_id": "TEST_ROOT", "children": ["TEST_A", "TEST_B"], "stakeholder": True, "retired": False},
+    # A -> C
+    {"_id": "TEST_A", "children": ["TEST_C"], "stakeholder": True, "retired": False},
+    # B -> C (shared with A), B -> RETIRED (non-stakeholder parent)
+    {"_id": "TEST_B", "children": ["TEST_C", "TEST_RETIRED"], "stakeholder": False, "retired": False},
+    # C is a shared leaf
+    {"_id": "TEST_C", "children": [], "stakeholder": True, "retired": False},
+    # RETIRED prunes its subtree unless include_retired=True
+    {"_id": "TEST_RETIRED", "children": ["TEST_UNDER_RETIRED"], "stakeholder": True, "retired": True},
+    {"_id": "TEST_UNDER_RETIRED", "children": [], "stakeholder": True, "retired": False},
+]
+
+
+@pytest.fixture
+def request_hierarchy(database):
+    """Insert a known request hierarchy, then remove it after the test.
+
+    Documents are inserted directly into the collection (bypassing mongokit
+    validation) since only the hierarchy fields matter here.
+    """
+    database.requests.remove({"_id": {"$in": _HIERARCHY_IDS}})
+    database.requests.insert(_HIERARCHY_DOCS)
+    yield database
+    database.requests.remove({"_id": {"$in": _HIERARCHY_IDS}})
+
+
+class TestGetAllDescendantsIntegration:
+    """End-to-end tests that exercise _load_org_info() against MongoDB."""
+
+    def test_default_excludes_retired_subtree_and_dedupes(self, request_hierarchy):
+        result = request_hierarchy.RequestDoc.get_all_descendants("TEST_ROOT")
+        assert sorted(result) == ["TEST_A", "TEST_B", "TEST_C"]
+
+    def test_include_retired(self, request_hierarchy):
+        result = request_hierarchy.RequestDoc.get_all_descendants(
+            "TEST_ROOT", include_retired=True
+        )
+        assert sorted(result) == [
+            "TEST_A",
+            "TEST_B",
+            "TEST_C",
+            "TEST_RETIRED",
+            "TEST_UNDER_RETIRED",
+        ]
+
+    def test_stakeholders_only(self, request_hierarchy):
+        # TEST_B is a non-stakeholder: excluded from membership but still
+        # traversed, so TEST_C (reached via TEST_B) is still found.
+        result = request_hierarchy.RequestDoc.get_all_descendants(
+            "TEST_ROOT", stakeholders_only=True
+        )
+        assert sorted(result) == ["TEST_A", "TEST_C"]
+
+    def test_unknown_owner_raises(self, request_hierarchy):
+        with pytest.raises(ValueError):
+            request_hierarchy.RequestDoc.get_all_descendants("TEST_DOES_NOT_EXIST")

--- a/cyhy/test/test_request_hierarchy.py
+++ b/cyhy/test/test_request_hierarchy.py
@@ -91,14 +91,27 @@ class TestDescendantsTraversal:
         assert sorted(result) == ["P1", "P2", "SHARED"]
         assert len(result) == len(set(result))  # no dupes
 
-    def test_cycle_terminates(self):
-        # A -> B -> A ; must not infinite loop.
+    def test_cycle_terminates_and_excludes_owner(self):
+        # A -> B -> A ; must not infinite loop, and the cycle back to the owner
+        # must not add the owner to its own descendants.
         org_info = make_org_info(
             make_org("A", ["B"]),
             make_org("B", ["A"]),
         )
         result = RequestDoc._descendants(org_info, "A")
-        assert sorted(result) == ["A", "B"]
+        assert sorted(result) == ["B"]
+        assert "A" not in result  # owner is never a descendant, even via a cycle
+
+    def test_self_referential_owner_excluded(self):
+        # A lists itself as a child; owner must still be excluded.
+        org_info = make_org_info(make_org("A", ["A", "B"]), make_org("B"))
+        result = RequestDoc._descendants(org_info, "A")
+        assert sorted(result) == ["B"]
+
+    def test_null_children_field_is_handled(self):
+        # children stored as None (rather than missing) must not raise.
+        org_info = make_org_info({"_id": "A", "children": None, "stakeholder": False, "retired": False})
+        assert RequestDoc._descendants(org_info, "A") == []
 
     def test_dangling_child_reference_is_skipped(self):
         # ROOT references GHOST which has no org document.

--- a/cyhy/test/test_request_hierarchy.py
+++ b/cyhy/test/test_request_hierarchy.py
@@ -110,7 +110,9 @@ class TestDescendantsTraversal:
 
     def test_null_children_field_is_handled(self):
         # children stored as None (rather than missing) must not raise.
-        org_info = make_org_info({"_id": "A", "children": None, "stakeholder": False, "retired": False})
+        org_info = make_org_info(
+            {"_id": "A", "children": None, "stakeholder": False, "retired": False}
+        )
         assert RequestDoc._descendants(org_info, "A") == []
 
     def test_dangling_child_reference_is_skipped(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.3.1",
+    version="1.3.2",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request refactors the organization hierarchy traversal logic in `RequestDoc` to improve efficiency and testability. It introduces a pure in-memory traversal method, optimizes database queries to fetch only necessary fields, and adds comprehensive unit and integration tests for hierarchy traversal. The version is bumped to 1.3.1.

**Hierarchy traversal and performance improvements:**

* Refactored `get_all_descendants` and `get_owner_to_type_dict` in `RequestDoc` to use a new `_descendants` static method that performs pure in-memory traversal, and a new `_load_org_info` helper that fetches only required fields from the database, reducing overhead and improving performance. The traversal now avoids duplicate visits, handles cycles, and skips missing references robustly.

**Testing enhancements:**

* Added a new test suite `test_request_hierarchy.py` with unit tests for the in-memory traversal logic and integration tests that exercise the hierarchy traversal against a real MongoDB instance, ensuring correct handling of edge cases (e.g., cycles, shared subtrees, retired orgs, stakeholder filtering).

**Version bump:**

* Updated the package version to 1.3.1 in both `cyhy/__init__.py` and `setup.py`. [[1]](diffhunk://#diff-de176a738d1d82530aa97a7ebd47536547937246911d745a5dcefd4ad59e7b2cL9-R9) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L5-R5)

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

During recent runs of the weekly reporting process, I noticed that it was taking over 5 minutes to build the list of snapshots to be generated:

```console
2026-07-13 13:06:12,019 INFO - Building list of reports to generate...
2026-07-13 13:06:12,064 INFO - Building list of snapshots to generate...
2026-07-13 13:11:55,500 INFO - [Thread-1] Starting snapshot for: CYHY_ENTITY
```

Digging into this, I saw that [we call `RequestDoc.get_all_descendants` many times](https://github.com/cisagov/cyhy-reports/blob/b4243269d045cb1d7d1b0bcead8e615ec3780ed9/extras/create_snapshots_reports_scorecard.py#L277) and I suspected that function was the reason why this step was taking such a long time to complete.

The changes in this PR result in significant performance improvements when doing a test against Production (over 12,000 entities) from my local system:

```python
# Legacy code
In [1]: import time
   ...: start_time = time.clock()
   ...: len(db.RequestDoc.get_all_descendants("ROOT"))
   ...: end_time = time.clock()
   ...: execution_time = end_time - start_time
   ...: print "Execution time: %.6f seconds" % execution_time
   ...:
Execution time: 4.017325 seconds

# Code from this PR
In [1]: import time
   ...: start_time = time.clock()
   ...: len(db.RequestDoc.get_all_descendants("ROOT"))
   ...: end_time = time.clock()
   ...: execution_time = end_time - start_time
   ...: print "Execution time: %.6f seconds" % execution_time
Execution time: 0.112626 seconds
``` 

NOTE: AI was used to generate most of the code in this PR.  I attest that I understand the generated code and am comfortable answering questions about it.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

The new set of unit and integration tests related to these changes that was added in this PR all passed.

Additionally, I spot checked a variety of entities to ensure that the descendant counts were unchanged when compared with the original code, for example:

```python
In [1]: len(db.RequestDoc.get_all_descendants("ROOT"))
Out[1]: 12401

In [2]: len(db.RequestDoc.get_all_descendants("ROOT", include_retired=True))
Out[2]: 12816

In [3]: len(db.RequestDoc.get_all_descendants("ROOT", stakeholders_only=True, include_retired=True))
Out[3]: 11327
```

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
- [x] Deploy this change to Production.
