### PR TITLE
Modify email address regex to allow ampersands before the `@` symbol

### DIFF
--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -1137,8 +1137,13 @@ class RequestDoc(RootDoc):
     __collection__ = REQUEST_COLLECTION
     # This regex was taken from the Python example at
     # https://emailregex.com/
+    #
+    # We have modified the example to allow an ampersand before the @
+    # symbol in email addresses.  This is technically allowed by RFC
+    # 5322 but is generally regarded as a bad idea; and yet, we have a
+    # customer who is doing this.  See #161 for more details.
     __EmailAddressRegex = re.compile(
-        r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
+        r"(^[a-zA-Z0-9&_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
     )
     structure = {
         "agency": {


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the email address regex to allow ampersands before the `@` symbol.

## 💭 Motivation and context ##

This is technically allowed by RFC 5322 but is generally regarded as a bad idea; and yet, we have a customer who is doing this.  Resolves #161.

## 🧪 Testing ##

The only non-comment change was the addition of a single character.  What could go wrong?

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.