### PR TITLE
Bump version from 1.3.1 to 1.3.2

### DIFF
--- a/cyhy/__init__.py
+++ b/cyhy/__init__.py
@@ -6,7 +6,7 @@ __path__ = extend_path(__path__, __name__)
 import sys as _sys
 
 #: Version info (major, minor, maintenance, status)
-VERSION = (1, 3, 0)
+VERSION = (1, 3, 2)
 STATUS = ""
 __version__ = "%d.%d.%d" % VERSION[0:3] + STATUS
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.3.1",
+    version="1.3.2",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps the version from 1.3.1 to 1.3.2.

## 💭 Motivation and context ##

This version bump allows us to create a release containing the changes from #162.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release (necessary if and only if the version was bumped).
