### PR TITLE
Clear latest flag on scans for removed hostnames

### DIFF
--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -210,6 +210,26 @@ def remove(db, owner, domains):
         count += 1
     print "Closed %d open tickets referencing removed domain(s)" % count
 
+    # Clear the latest flag on scans referencing the removed domains so the
+    # removed domains no longer appear on customer reports (see
+    # cisagov/cyhy-core#164).  The update is scoped by owner so that host_scans
+    # and vuln_scans stamped with an nmap- or Nessus-discovered hostname on some
+    # other owner's IP (which can coincidentally match a removed domain) are
+    # left untouched.
+    for doc_class in (db.HostScanDoc, db.PortScanDoc, db.VulnScanDoc):
+        result = doc_class.collection.update(
+            {"latest": True, "owner": owner, "hostname": {"$in": domains}},
+            {"$set": {"latest": False}},
+            multi=True,
+            upsert=False,
+            safe=True,
+        )
+        modified = result.get("nModified", 0) if result else 0
+        print "Cleared latest flag on %d %s documents" % (
+            modified,
+            doc_class.collection.name,
+        )
+
 
 def check(db, domains):
     domain_owners = get_existing_domains_and_owners(db)

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -375,7 +375,7 @@ def move(db, orig_owner, new_owner, domains_to_move):
 
 
 def main():
-    args = docopt(__doc__, version="v1.3.0")
+    args = docopt(__doc__, version="v1.3.1")
 
     db = database.db_from_config(args["--section"], args["--config-file"])
 

--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -90,8 +90,41 @@ def close_tickets(db, ip, hostname, reason):
     return result["nModified"]
 
 
+def clear_latest_flags(db, ip, hostname):
+    """Clear the latest flag on scans for the given IP address and hostname.
+
+    When a hostname no longer resolves to an IP address, the host_scans,
+    port_scans, and vuln_scans that were generated for that IP/hostname
+    combination are no longer current.  If their latest flag is left set to
+    True, the removed domain continues to appear on customer reports (e.g. the
+    services.csv attachment).
+
+    Each of these scan documents carries an optional hostname field (see
+    cyhy-commander's nmap_importer, which creates one scan document per
+    hostname/owner combination), so the update is scoped to the specific
+    hostname and does not affect scan documents for other hostnames on the same IP.
+
+    Returns a dictionary mapping each scan collection name to the number of
+    documents modified, e.g. {"host_scans": 1, "port_scans": 3, "vuln_scans":
+    0}."""
+    modified = {}
+    for doc_class in (db.HostScanDoc, db.PortScanDoc, db.VulnScanDoc):
+        result = doc_class.collection.update(
+            {"latest": True, "ip_int": int(ip), "hostname": hostname},
+            {"$set": {"latest": False}},
+            multi=True,
+            upsert=False,
+        )
+        # An acknowledged update returns a response document with nModified;
+        # guard in case of an unacknowledged write concern.
+        modified[doc_class.__collection__] = (
+            result.get("nModified", 0) if result else 0
+        )
+    return modified
+
+
 def main():
-    args = docopt(__doc__, version="v1.0.4")
+    args = docopt(__doc__, version="v1.0.5")
 
     # Dictionary to track certain DNS exceptions encountered during processing
     dns_exceptions = {
@@ -243,6 +276,24 @@ def main():
                             i for i in host["hostnames"] if i["hostname"] != hostname
                         ]
                         host.save()
+
+                        # Clear the latest flag on now-defunct scan docs for this
+                        # ip and hostname so the removed domain no longer shows
+                        # up in customer reports
+                        cleared_counts = clear_latest_flags(db, host.ip, hostname)
+                        print(
+                            "  latest flag cleared for %s[%s]: %s"
+                            % (
+                                host.ip,
+                                hostname,
+                                ", ".join(
+                                    "%d %s" % (count, collection)
+                                    for collection, count in sorted(
+                                        cleared_counts.items()
+                                    )
+                                ),
+                            )
+                        )
 
                         # Close all open tickets with this ip and hostname
                         closed_count = close_tickets(

--- a/bin/cyhy-domainsync
+++ b/bin/cyhy-domainsync
@@ -117,9 +117,7 @@ def clear_latest_flags(db, ip, hostname):
         )
         # An acknowledged update returns a response document with nModified;
         # guard in case of an unacknowledged write concern.
-        modified[doc_class.__collection__] = (
-            result.get("nModified", 0) if result else 0
-        )
+        modified[doc_class.__collection__] = result.get("nModified", 0) if result else 0
     return modified
 
 

--- a/cyhy/__init__.py
+++ b/cyhy/__init__.py
@@ -6,7 +6,7 @@ __path__ = extend_path(__path__, __name__)
 import sys as _sys
 
 #: Version info (major, minor, maintenance, status)
-VERSION = (1, 3, 2)
+VERSION = (1, 3, 3)
 STATUS = ""
 __version__ = "%d.%d.%d" % VERSION[0:3] + STATUS
 

--- a/cyhy/db/database.py
+++ b/cyhy/db/database.py
@@ -690,6 +690,22 @@ class ScanDoc(RootDoc):
     def get_indices(self):  # used by all subclasses
         return (
             ("latest_ip", [("latest", 1), ("ip_int", 1)], False, False),
+            # Supports the cyhy-domainsync query that clears the latest flag for
+            # a specific ip/hostname when a hostname stops resolving to an IP.
+            (
+                "latest_ip_int_hostname",
+                [("latest", 1), ("ip_int", 1), ("hostname", 1)],
+                False,
+                False,
+            ),
+            # Supports the cyhy-domain query that clears the latest flag for a
+            # removed owner/hostname combination.
+            (
+                "latest_owner_hostname",
+                [("latest", 1), ("owner", 1), ("hostname", 1)],
+                False,
+                False,
+            ),
             ("time_owner", [("time", 1), ("owner", 1)], False, False),
             ("ip_int", [("ip_int", 1)], False, False),
             ("snapshots", [("snapshots", 1)], False, True),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.3.2",
+    version="1.3.3",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

## 🗣 Description ##

Clear the `latest` flag on scan documents (`host_scans`, `port_scans`, `vuln_scans`) when a customer-provided hostname goes out of scope, so removed domains stop appearing on customer reports (e.g. the `services.csv` attachment). Two distinct code paths are addressed:

- **`cyhy-domain remove()`** — when a domain is explicitly removed from an organization, clear `latest` on scans matching that `owner` + `hostname`. Scoped by `owner` so scans stamped with an nmap- or Nessus-discovered hostname on another owner's IP (which can coincidentally match a removed domain) are left untouched. Tool version bumped to `v1.3.1`.
- **`cyhy-domainsync`** — when a still-owned hostname stops resolving to an IP (DNS drift or non-resolution), clear `latest` on scans matching that `ip_int` + `hostname`, alongside the existing ticket-closing logic. A per-collection count of modified documents is logged. Tool version bumped to `v1.0.5`.

Supporting changes:

- Add two compound indices to the shared `ScanDoc.get_indices()` (inherited by all three scan collections): `latest_ip_int_hostname` `(latest, ip_int, hostname)` for the `cyhy-domainsync` query, and `latest_owner_hostname` `(latest, owner, hostname)` for the `cyhy-domain` query.
- Bump the package version from 1.3.2 to 1.3.3.

## 💭 Motivation and context ##

Closes #164.

When a hostname left scope, the existing cleanup removed it from host documents and closed its open tickets, but never cleared the `latest` flag on the corresponding scan documents. As a result, the removed domain's scans continued to be treated as current and kept showing up on customer reports. Two situations cause a hostname to leave scope, and both are now handled: explicit removal via `cyhy-domain`, and a still-owned hostname that stops resolving to an IP (handled during `cyhy-domainsync`, which is the only place that detects the latter and is also where the now-defunct host may be deleted and never rescanned).

## 🧪 Testing ##

Verified in a development database:

- Built the two new scan-collection indices via the index-ensuring path with no errors.
- Identified a customer-owned hostname with `latest: true` scan documents, removed it with `cyhy-domain remove`, and confirmed the `latest` flag was cleared on the relevant `host_scans`, `port_scans`, and `vuln_scans` documents.
- `python -m py_compile` passes for `bin/cyhy-domain`, `bin/cyhy-domainsync`, and `cyhy/db/database.py`.

Not exercised end-to-end: the `cyhy-domainsync` DNS-drift branch (would require a live DNS change for a still-owned hostname). Its behavior and necessity are documented in the code comments.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release (necessary if and only if the version was bumped).
- [x] Deploy these changes to Production
- [x] Rebuild the Production indices (`cyhy-tool ensure-indices`) as soon as possible after deployment (it will take a while since the `port_scans` collection is quite large)
- [x] Ensure CyHy operators use latest version
- [x] Run one-off backfill script in Production to flip `latest` flags to `false` for scan documents associated with removed hostnames