### PR TITLE
Declare test dependencies and decouple tests from the local environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,66 @@ sudo pip install numpy
 sudo pip install geos
 sudo pip install --requirement requirements.txt
 ```
+
+## Testing ##
+
+### Installing the test dependencies ###
+
+```console
+pip install --requirement requirements-test.txt
+```
+
+This installs the project along with everything needed to run the test suite:
+`pytest`, `mock`, `pyfakefs`, and
+[`cyhy-commander`](https://github.com/cisagov/cyhy-commander) (which is not
+published to PyPI and is therefore installed directly from GitHub, so `git`
+must be available).
+
+### Running the tests ###
+
+The test suite can be run from any directory:
+
+```console
+pytest
+```
+
+To run a single test file, or a single test:
+
+```console
+pytest cyhy/test/test_yaml_config.py
+pytest cyhy/test/test_yaml_config.py::TestYamlConfig::test_load_proper_config
+```
+
+### Tests that require MongoDB ###
+
+Most tests run without any additional setup, but the tests that exercise the
+database layer (for example `test_database.py`, `test_ticket_manager.py`, and
+`test_request_hierarchy.py`) need a running MongoDB instance.
+
+Start one with Docker:
+
+```console
+docker run --rm --publish 27037:27017 mongo:3.6
+```
+
+Port 27037 is used to avoid colliding with a MongoDB instance -- or an SSH
+tunnel to a production database -- already listening on the default port of
+27017.
+
+These tests read their connection information from the `testing` section of
+your CyHy configuration file, so that section must point at the MongoDB
+instance above:
+
+```ini
+[DEFAULT]
+default-section = testing
+report-key = test-report-key
+
+[testing]
+database-uri = mongodb://localhost:27037/test-cyhy
+database-name = test-cyhy
+```
+
+**WARNING: The database-backed tests add, modify, and remove documents in the
+configured database.  Never point the `testing` section at a database that
+contains data you care about.**

--- a/cyhy/test/paths.py
+++ b/cyhy/test/paths.py
@@ -1,0 +1,23 @@
+"""Helpers for locating test input files.
+
+Test input files are referenced relative to this directory rather than the
+current working directory so that the test suite can be run from anywhere,
+e.g. both `pytest` at the repository root and `pytest .` in this directory.
+"""
+
+import os
+
+# Absolute path to the directory holding this module.
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Absolute path to the directory holding the test input files.
+INPUTS_DIR = os.path.join(TEST_DIR, "inputs")
+
+
+def input_path(*parts):
+    """Return the absolute path to a test input file.
+
+    For example, input_path("test_all.yml") returns the absolute path to
+    cyhy/test/inputs/test_all.yml.
+    """
+    return os.path.join(INPUTS_DIR, *parts)

--- a/cyhy/test/test_database.py
+++ b/cyhy/test/test_database.py
@@ -2,14 +2,33 @@
 
 import pytest
 import cyhy.db.database as db
+from cyhy.core.config import DEFAULT_CONFIG_FILENAME
 from cyhy.core.yaml_config import YamlConfig
 from paths import input_path
 import mock
 
+# Contents of the fake default configuration file used by
+# test_from_config_etc().  Creating this file in a fake filesystem keeps the
+# test independent of whatever configuration happens to exist on the machine
+# running the test suite.
+DEFAULT_CONFIG_CONTENTS = """[DEFAULT]
+default-section = testing
+report-key = test-report-key
+
+[testing]
+database-uri = mongodb://test:test@localhost:27017/test-cyhy
+database-name = test-cyhy
+"""
+
 
 class TestDatabase:
     @mock.patch("cyhy.db.database.db_from_connection")
-    def test_from_config_etc(self, mock_db_from_connection):
+    def test_from_config_etc(self, mock_db_from_connection, fs):
+        # The fs fixture is provided by pyfakefs and replaces the filesystem for
+        # the duration of this test, so the configuration file created below
+        # shadows the real /etc/cyhy/cyhy.conf.
+        fs.create_file(DEFAULT_CONFIG_FILENAME, contents=DEFAULT_CONFIG_CONTENTS)
+
         db.db_from_config()  # default section set to testing
         mock_db_from_connection.assert_called_with(
             "mongodb://test:test@localhost:27017/test-cyhy", "test-cyhy"

--- a/cyhy/test/test_database.py
+++ b/cyhy/test/test_database.py
@@ -3,6 +3,7 @@
 import pytest
 import cyhy.db.database as db
 from cyhy.core.yaml_config import YamlConfig
+from paths import input_path
 import mock
 
 
@@ -21,24 +22,24 @@ class TestDatabase:
 
     @mock.patch("cyhy.db.database.db_from_connection")
     def test_from_config_conf(self, mock_db_from_connection):
-        db.db_from_config("testconf", "inputs/test-conf.conf")
+        db.db_from_config("testconf", input_path("test-conf.conf"))
         mock_db_from_connection.assert_called_with(
             "mongodb://test:test@localhost:27017/test-conf", "test-name"
         )
 
-        db.db_from_config(config_filename="inputs/test-conf.conf")
+        db.db_from_config(config_filename=input_path("test-conf.conf"))
         mock_db_from_connection.assert_called_with(
             "mongodb://test:test@localhost:27017/test-conf", "test-name"
         )
 
     @mock.patch("cyhy.db.database.db_from_connection")
     def test_from_config_yml(self, mock_db_from_connection):
-        db.db_from_config("default", "inputs/test_all.yml", True)
+        db.db_from_config("default", input_path("test_all.yml"), True)
         mock_db_from_connection.assert_called_with(
             "mongodb://dbuser:dbpass@localhost:27017/local", "localuser"
         )
 
-        db.db_from_config(config_filename="inputs/test_all.yml", yaml=True)
+        db.db_from_config(config_filename=input_path("test_all.yml"), yaml=True)
         mock_db_from_connection.assert_called_with(
             "mongodb://dbuser:dbpass@localhost:27017/local", "localuser"
         )

--- a/cyhy/test/test_nmap_handler.py
+++ b/cyhy/test/test_nmap_handler.py
@@ -11,9 +11,10 @@ import pytest
 
 import cyhy.util as util
 from cyhy_commander.nmap.nmap_handler import NmapContentHandler
+from paths import input_path
 from xml.sax import parse
 
-TEST_NMAP_FILENAME = "inputs/test-fullscan.xml"
+TEST_NMAP_FILENAME = input_path("test-fullscan.xml")
 
 
 def pytest_runtest_makereport(item, call):

--- a/cyhy/test/test_yaml_config.py
+++ b/cyhy/test/test_yaml_config.py
@@ -3,12 +3,13 @@
 import pytest
 from yaml import YAMLError
 from cyhy.core.yaml_config import YamlConfig
+from paths import input_path
 
 
 class TestYamlConfig:
     @pytest.fixture
     def yc(self):
-        return YamlConfig("inputs/test_all.yml")
+        return YamlConfig(input_path("test_all.yml"))
 
     @pytest.fixture
     def sample_config(self):
@@ -50,22 +51,22 @@ class TestYamlConfig:
 
     def test_load_config_non_yaml_file(self):
         with pytest.raises(YAMLError):
-            yc = YamlConfig("inputs/test-fullscan.xml")
+            yc = YamlConfig(input_path("test-fullscan.xml"))
 
     def test_load_config_corrupt_yaml_file(self):
         with pytest.raises(YAMLError):
-            yc = YamlConfig("inputs/corrupt_yaml.yml")
+            yc = YamlConfig(input_path("corrupt_yaml.yml"))
 
     def test_load_config_no_cyhy_version(self):
         with pytest.raises(KeyError):
-            yc = YamlConfig("inputs/no_version.yml")
+            yc = YamlConfig(input_path("no_version.yml"))
 
     def test_load_config_wrong_cyhy_version(self):
         with pytest.raises(ValueError):
-            yc = YamlConfig("inputs/bad_version.yml")
+            yc = YamlConfig(input_path("bad_version.yml"))
 
     def test_load_proper_config(self, sample_config):
-        yc = YamlConfig("inputs/test_all.yml")
+        yc = YamlConfig(input_path("test_all.yml"))
         assert isinstance(yc, YamlConfig)
         assert yc.config == sample_config
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+--index-url https://pypi.python.org/simple/
+-e .[test]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,1 @@
---index-url https://pypi.python.org/simple/
 -e .[test]

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,5 @@
 from setuptools import setup, find_packages
 
-# Packages required to run the test suite.  Note that several upper bounds are
-# necessary because this project still targets Python 2.7.
-#
-# These are deliberately *not* added to the "dev" extra: the Dockerfile runs
-# "pip install .[dev]" and the image does not include git, so a VCS requirement
-# there would break the Docker build.
-TEST_REQUIREMENTS = [
-    # cyhy-commander is not published to PyPI, so it is referenced directly from
-    # GitHub.  It is required by cyhy/test/test_nmap_handler.py, which exercises
-    # cyhy_commander.nmap.nmap_handler.
-    "cyhy-commander @ git+https://github.com/cisagov/cyhy-commander.git@develop",
-    "mock >= 2.0.0",
-    # pyfakefs 4.0 dropped Python 2.7 support.
-    "pyfakefs >= 3.7, < 4.0",
-    # pytest 5.0 dropped Python 2.7 support.
-    "pytest >= 4.6, < 5.0",
-]
-
 setup(
     name="cyhy-core",
     version="1.3.3",
@@ -67,6 +49,20 @@ setup(
     ],
     extras_require={
         "dev": ["ipython >= 5.8.0", "mock >= 2.0.0"],
-        "test": TEST_REQUIREMENTS,
+        # These are deliberately not included in the "dev" extra above: the
+        # Dockerfile runs "pip install .[dev]" and the image does not include
+        # git, so the VCS requirement below would break the Docker build.
+        "test": [
+            # cyhy-commander is not published to PyPI, so it is referenced
+            # directly from GitHub.  It is required by
+            # cyhy/test/test_nmap_handler.py, which exercises
+            # cyhy_commander.nmap.nmap_handler.
+            "cyhy-commander @ git+https://github.com/cisagov/cyhy-commander.git@develop",
+            "mock >= 2.0.0",
+            # pyfakefs 4.0 dropped Python 2.7 support.
+            "pyfakefs >= 3.7, < 4.0",
+            # pytest 5.0 dropped Python 2.7 support.
+            "pytest >= 4.6, < 5.0",
+        ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,20 @@
 from setuptools import setup, find_packages
 
 # Packages required to run the test suite.  Note that several upper bounds are
-# necessary because this project still targets Python 2.7:
-#   * pytest 5.0 dropped Python 2.7 support.
-#   * pyfakefs 4.0 dropped Python 2.7 support.
-#
-# cyhy-commander is not published to PyPI, so it is referenced directly from
-# GitHub.  It is required by cyhy/test/test_nmap_handler.py, which exercises
-# cyhy_commander.nmap.nmap_handler.
+# necessary because this project still targets Python 2.7.
 #
 # These are deliberately *not* added to the "dev" extra: the Dockerfile runs
 # "pip install .[dev]" and the image does not include git, so a VCS requirement
 # there would break the Docker build.
 TEST_REQUIREMENTS = [
+    # cyhy-commander is not published to PyPI, so it is referenced directly from
+    # GitHub.  It is required by cyhy/test/test_nmap_handler.py, which exercises
+    # cyhy_commander.nmap.nmap_handler.
     "cyhy-commander @ git+https://github.com/cisagov/cyhy-commander.git@develop",
     "mock >= 2.0.0",
+    # pyfakefs 4.0 dropped Python 2.7 support.
     "pyfakefs >= 3.7, < 4.0",
+    # pytest 5.0 dropped Python 2.7 support.
     "pytest >= 4.6, < 5.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,24 @@
 from setuptools import setup, find_packages
 
+# Packages required to run the test suite.  Note that several upper bounds are
+# necessary because this project still targets Python 2.7:
+#   * pytest 5.0 dropped Python 2.7 support.
+#   * pyfakefs 4.0 dropped Python 2.7 support.
+#
+# cyhy-commander is not published to PyPI, so it is referenced directly from
+# GitHub.  It is required by cyhy/test/test_nmap_handler.py, which exercises
+# cyhy_commander.nmap.nmap_handler.
+#
+# These are deliberately *not* added to the "dev" extra: the Dockerfile runs
+# "pip install .[dev]" and the image does not include git, so a VCS requirement
+# there would break the Docker build.
+TEST_REQUIREMENTS = [
+    "cyhy-commander @ git+https://github.com/cisagov/cyhy-commander.git@develop",
+    "mock >= 2.0.0",
+    "pyfakefs >= 3.7, < 4.0",
+    "pytest >= 4.6, < 5.0",
+]
+
 setup(
     name="cyhy-core",
     version="1.3.3",
@@ -47,5 +66,8 @@ setup(
         "six >= 1.9",
         "validators == 0.14.2",
     ],
-    extras_require={"dev": ["ipython >= 5.8.0", "mock >= 2.0.0"]},
+    extras_require={
+        "dev": ["ipython >= 5.8.0", "mock >= 2.0.0"],
+        "test": TEST_REQUIREMENTS,
+    },
 )


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

## 🗣 Description ##

First of several changes for #159.  This one covers everything that does not require new infrastructure:

- **Declare the test dependencies.** Add a `test` extra to `setup.py` containing `pytest`, `mock`, `pyfakefs`, and `cyhy-commander`, plus a `requirements-test.txt` so they can be installed with one command. Upper bounds are needed on `pytest` (`< 5.0`) and `pyfakefs` (`< 4.0`) because those projects dropped Python 2.7 support in those releases. `cyhy-commander` is not published to PyPI, so it is referenced directly from GitHub.
- **Make the suite work from any directory.** Test inputs were referenced by paths relative to the current working directory, so the suite only passed when run from `cyhy/test`. Add a `cyhy/test/paths.py` helper that resolves inputs relative to the test directory and use it at every input reference.
- **Isolate the default config test from the machine.** `test_from_config_etc` asserted the contents of the developer's real `/etc/cyhy/cyhy.conf`, so it only passed if that machine-wide file happened to match. Use `pyfakefs` to supply a known configuration in a fake filesystem instead.
- **Document it.** Add a Testing section to the README covering dependency installation, running the suite, and the MongoDB instance and `testing` configuration section that the database-backed tests need.

Deliberately **not** added to the `dev` extra: the Dockerfile runs `pip install .[dev]` and the image does not include `git`, so adding a VCS requirement there would break the Docker build.

## 💭 Motivation and context ##

Contributes to #159.

Testing did not work out of the box.  A new contributor had to discover, with no documentation, that they needed to install three undeclared packages, create a machine-wide config file whose contents had to match a test assertion, stand up MongoDB, and run `pytest` from one specific directory.

The config-file coupling was not hypothetical: it produced local edits to `test_database.py` and `common_fixtures.py` that developers carried in their working trees indefinitely, which is easy to commit by accident.

## 🧪 Testing ##

Before this change, running `pytest` from the repository root produced 27 failures of the form `IOError: [Errno 2] No such file or directory: 'inputs/test_all.yml'`.  The suite passed only when invoked from `cyhy/test`.

After this change, the tests that do not require MongoDB pass identically from both locations:

| Invoked from | Result |
| --- | --- |
| repository root | 45 passed |
| `cyhy/test` | 45 passed |

With a MongoDB instance matching the `testing` configuration section, the full suite passes from the repository root (192 passed), which was not previously possible from that directory.

`test_from_config_etc` was verified to be genuinely isolated: it asserts a URI on port 27017 and passes on a machine whose real `/etc/cyhy/cyhy.conf` specifies port 27037.

`pip install "pyfakefs>=3.7,<4.0"` was confirmed to resolve to 3.7.2 under Python 2.7, and `python setup.py egg_info` was confirmed to emit the `test` extra with all four requirements, including the direct URL reference.

## ➡️ Follow-up work for #159 ##

Not included here, to keep this reviewable:

1. A Docker composition to stand up MongoDB (`mongo:3.6`), and reworking the `database` fixture to connect directly via a URI rather than through a config file. That removes the last machine-specific requirement and lets the remaining local workaround in `common_fixtures.py` be dropped.
2. A CI workflow that runs the suite.  Note that `actions/setup-python` no longer offers Python 2.7 on current runners, so this will likely need to run inside a Python 2.7 container with MongoDB as a service container.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
