### PR TITLE
Provide MongoDB for the tests via a Docker composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,32 +221,33 @@ pytest cyhy/test/test_yaml_config.py::TestYamlConfig::test_load_proper_config
 
 Most tests run without any additional setup, but the tests that exercise the
 database layer (for example `test_database.py`, `test_ticket_manager.py`, and
-`test_request_hierarchy.py`) need a running MongoDB instance.
-
-Start one with Docker:
+`test_request_hierarchy.py`) need a running MongoDB instance.  A Docker
+composition is included for this purpose:
 
 ```console
-docker run --rm --publish 27037:27017 mongo:3.6
+docker compose up --detach --wait
 ```
 
-Port 27037 is used to avoid colliding with a MongoDB instance -- or an SSH
+The tests connect to that instance by default, so no configuration is required.
+Port 27037 is published to avoid colliding with a MongoDB instance -- or an SSH
 tunnel to a production database -- already listening on the default port of
 27017.
 
-These tests read their connection information from the `testing` section of
-your CyHy configuration file, so that section must point at the MongoDB
-instance above:
+When you are finished, stop the instance and discard its data:
 
-```ini
-[DEFAULT]
-default-section = testing
-report-key = test-report-key
+```console
+docker compose down
+```
 
-[testing]
-database-uri = mongodb://localhost:27037/test-cyhy
-database-name = test-cyhy
+To run the tests against some other MongoDB instance instead, set
+`CYHY_TEST_DB_URI` and, if the database name differs, `CYHY_TEST_DB_NAME`:
+
+```console
+CYHY_TEST_DB_URI=mongodb://localhost:27017/my-test-db \
+  CYHY_TEST_DB_NAME=my-test-db \
+  pytest
 ```
 
 **WARNING: The database-backed tests add, modify, and remove documents in the
-configured database.  Never point the `testing` section at a database that
-contains data you care about.**
+database they are pointed at.  Never point them at a database that contains
+data you care about.**

--- a/README.md
+++ b/README.md
@@ -221,29 +221,41 @@ pytest cyhy/test/test_yaml_config.py::TestYamlConfig::test_load_proper_config
 
 Most tests run without any additional setup, but the tests that exercise the
 database layer (for example `test_database.py`, `test_ticket_manager.py`, and
-`test_request_hierarchy.py`) need a running MongoDB instance.  A Docker
-composition is included for this purpose:
+`test_request_hierarchy.py`) need a running MongoDB instance.  The test suite
+starts one automatically using the Docker composition included in this
+repository, waits for it to become healthy, and shuts it down when the run
+finishes.  No additional steps are required:
+
+```console
+pytest
+```
+
+Docker must therefore be available to run those tests.  The tests that do not
+use MongoDB run without it.
+
+The MongoDB instance is published on port 27037 to avoid colliding with an
+instance -- or an SSH tunnel to a production database -- already listening on
+the default port of 27017.  No volumes are configured for the composition, so
+its data is discarded when it is shut down.
+
+#### Managing MongoDB yourself ####
+
+Set `CYHY_TEST_SKIP_COMPOSE` to keep the test suite from starting and stopping
+the composition.  This is useful for leaving an instance running between test
+runs while debugging, or when a suitable instance is provided some other way:
 
 ```console
 docker compose up --detach --wait
-```
-
-The tests connect to that instance by default, so no configuration is required.
-Port 27037 is published to avoid colliding with a MongoDB instance -- or an SSH
-tunnel to a production database -- already listening on the default port of
-27017.
-
-When you are finished, stop the instance and discard its data:
-
-```console
+CYHY_TEST_SKIP_COMPOSE=1 pytest
 docker compose down
 ```
 
-To run the tests against some other MongoDB instance instead, set
-`CYHY_TEST_DB_URI` and, if the database name differs, `CYHY_TEST_DB_NAME`:
+To run the tests against a different MongoDB instance, set `CYHY_TEST_DB_URI`
+and, if the database name differs, `CYHY_TEST_DB_NAME`:
 
 ```console
-CYHY_TEST_DB_URI=mongodb://localhost:27017/my-test-db \
+CYHY_TEST_SKIP_COMPOSE=1 \
+  CYHY_TEST_DB_URI=mongodb://localhost:27017/my-test-db \
   CYHY_TEST_DB_NAME=my-test-db \
   pytest
 ```

--- a/README.md
+++ b/README.md
@@ -230,8 +230,11 @@ finishes.  No additional steps are required:
 pytest
 ```
 
-Docker must therefore be available to run those tests.  The tests that do not
-use MongoDB run without it.
+Docker must therefore be available to run those tests, including the Docker
+Compose plugin, since the composition is driven with `docker compose`.  Docker
+Desktop bundles the plugin, but on some Linux distributions it is packaged
+separately as `docker-compose-plugin`.  The tests that do not use MongoDB run
+without any of this.
 
 The MongoDB instance is published on port 27037 to avoid colliding with an
 instance -- or an SSH tunnel to a production database -- already listening on

--- a/cyhy/test/common_fixtures.py
+++ b/cyhy/test/common_fixtures.py
@@ -4,22 +4,14 @@ import pytest
 
 from cyhy.db import database as pcsdb
 from cyhy.db import CHDatabase
-
-# Connection information for the MongoDB instance used by the tests.  These
-# defaults match the instance created by the Docker composition at the root of
-# this repository (see docker-compose.yml), so the tests require no
-# configuration to run against it.
-DEFAULT_DB_URI = "mongodb://localhost:27037/test-cyhy"
-DEFAULT_DB_NAME = "test-cyhy"
-
-# Environment variables used to run the tests against a different MongoDB
-# instance.
-DB_URI_VAR = "CYHY_TEST_DB_URI"
-DB_NAME_VAR = "CYHY_TEST_DB_NAME"
+from testenv import DB_NAME_VAR, DB_URI_VAR, DEFAULT_DB_NAME, DEFAULT_DB_URI
 
 
 @pytest.fixture
-def database():
+def database(dockerc):
+    # The dockerc fixture guarantees that MongoDB is up and accepting
+    # connections before this fixture is used.
+    #
     # Connect directly instead of by way of db_from_config() so that running the
     # tests does not require a CyHy configuration file to be installed at
     # /etc/cyhy/cyhy.conf, and so a test run cannot be pointed at a production

--- a/cyhy/test/common_fixtures.py
+++ b/cyhy/test/common_fixtures.py
@@ -1,14 +1,33 @@
+import os
+
 import pytest
+
 from cyhy.db import database as pcsdb
 from cyhy.db import CHDatabase
+
+# Connection information for the MongoDB instance used by the tests.  These
+# defaults match the instance created by the Docker composition at the root of
+# this repository (see docker-compose.yml), so the tests require no
+# configuration to run against it.
+DEFAULT_DB_URI = "mongodb://localhost:27037/test-cyhy"
+DEFAULT_DB_NAME = "test-cyhy"
+
+# Environment variables used to run the tests against a different MongoDB
+# instance.
+DB_URI_VAR = "CYHY_TEST_DB_URI"
+DB_NAME_VAR = "CYHY_TEST_DB_NAME"
 
 
 @pytest.fixture
 def database():
-    # connection = MongoClient('mongodb://tester:tester@[::1]:27017/test_database2', 27017)
-    # db = connection['test_database2']
-    db = pcsdb.db_from_config("testing")
-    return db
+    # Connect directly instead of by way of db_from_config() so that running the
+    # tests does not require a CyHy configuration file to be installed at
+    # /etc/cyhy/cyhy.conf, and so a test run cannot be pointed at a production
+    # database by whatever configuration happens to be on the machine.
+    return pcsdb.db_from_connection(
+        os.environ.get(DB_URI_VAR, DEFAULT_DB_URI),
+        os.environ.get(DB_NAME_VAR, DEFAULT_DB_NAME),
+    )
 
 
 @pytest.fixture

--- a/cyhy/test/conftest.py
+++ b/cyhy/test/conftest.py
@@ -11,19 +11,28 @@ import subprocess
 import pytest
 
 # cisagov Libraries
-from paths import COMPOSE_FILE
+from paths import COMPOSE_FILE, REPO_ROOT
 from testenv import DB_URI_VAR, SKIP_COMPOSE_VAR
 
 
 def compose(*args):
     """Run a docker compose command against our composition.
 
-    Returns the output of the command.  Note that the composition is identified
-    by its file rather than by an explicit project name, so that this matches the
-    project name Docker Compose derives when the composition is brought up by
-    hand from the root of the repository.
+    Returns the output of the command.  The project directory is specified
+    explicitly rather than left to Docker Compose to infer, so that the project
+    name is derived from the root of the repository no matter which directory
+    pytest was invoked from.  That keeps this in agreement with the project name
+    used when the composition is brought up by hand from the repository root, so
+    the two cannot end up managing separate sets of containers.
     """
-    command = ["docker", "compose", "--file", COMPOSE_FILE] + list(args)
+    command = [
+        "docker",
+        "compose",
+        "--project-directory",
+        REPO_ROOT,
+        "--file",
+        COMPOSE_FILE,
+    ] + list(args)
     try:
         return subprocess.check_output(command, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as err:
@@ -33,10 +42,10 @@ def compose(*args):
         )
     except OSError as err:
         raise RuntimeError(
-            'Unable to run "%s": %s.\n\nDocker is required to run the tests that '
-            "use MongoDB.  Alternatively, set %s to point at an existing MongoDB "
-            "instance and set %s to keep the test suite from managing the "
-            "composition itself."
+            'Unable to run "%s": %s.\n\nDocker, including the Docker Compose '
+            "plugin, is required to run the tests that use MongoDB. "
+            "Alternatively, set %s to point at an existing MongoDB instance and "
+            "set %s to keep the test suite from managing the composition itself."
             % (" ".join(command), err, DB_URI_VAR, SKIP_COMPOSE_VAR)
         )
 

--- a/cyhy/test/conftest.py
+++ b/cyhy/test/conftest.py
@@ -1,0 +1,73 @@
+"""pytest plugin configuration.
+
+https://docs.pytest.org/en/latest/writing_plugins.html#conftest-py-plugins
+"""
+
+# Standard Python Libraries
+import os
+import subprocess
+
+# Third-Party Libraries
+import pytest
+
+# cisagov Libraries
+from paths import COMPOSE_FILE
+from testenv import DB_URI_VAR, SKIP_COMPOSE_VAR
+
+
+def compose(*args):
+    """Run a docker compose command against our composition.
+
+    Returns the output of the command.  Note that the composition is identified
+    by its file rather than by an explicit project name, so that this matches the
+    project name Docker Compose derives when the composition is brought up by
+    hand from the root of the repository.
+    """
+    command = ["docker", "compose", "--file", COMPOSE_FILE] + list(args)
+    try:
+        return subprocess.check_output(command, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as err:
+        raise RuntimeError(
+            '"%s" failed with exit status %d:\n%s'
+            % (" ".join(command), err.returncode, err.output)
+        )
+    except OSError as err:
+        raise RuntimeError(
+            'Unable to run "%s": %s.\n\nDocker is required to run the tests that '
+            "use MongoDB.  Alternatively, set %s to point at an existing MongoDB "
+            "instance and set %s to keep the test suite from managing the "
+            "composition itself."
+            % (" ".join(command), err, DB_URI_VAR, SKIP_COMPOSE_VAR)
+        )
+
+
+@pytest.fixture(scope="session")
+def dockerc():
+    """Start up the Docker composition, and shut it down when finished.
+
+    This spares developers from having to remember to start MongoDB before
+    running the tests.  "--wait" blocks until the MongoDB container reports
+    healthy, so the tests cannot race its startup.
+
+    The composition is brought up once per test session rather than once per
+    test, since the tests that use it already reset the collections they touch.
+    No volumes are configured for the composition, so bringing it down discards
+    its data.
+
+    Set the environment variable named by SKIP_COMPOSE_VAR to bypass this
+    entirely and use a MongoDB instance managed elsewhere.  Note that when this
+    fixture is in charge, it shuts the composition down at the end of the
+    session even if the composition was already running beforehand.
+
+    This mirrors the approach used in cisagov/guacscanner, which drives its
+    composition with python-on-whales.  That library requires Python 3.8 or
+    newer, so it cannot be used here until this project leaves Python 2.7
+    behind; docker compose is invoked directly in the meantime.
+    """
+    if os.environ.get(SKIP_COMPOSE_VAR):
+        yield None
+        return
+
+    compose("up", "--detach", "--wait")
+    yield None
+    compose("down")

--- a/cyhy/test/paths.py
+++ b/cyhy/test/paths.py
@@ -13,6 +13,12 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 # Absolute path to the directory holding the test input files.
 INPUTS_DIR = os.path.join(TEST_DIR, "inputs")
 
+# Absolute path to the root of the repository.
+REPO_ROOT = os.path.dirname(os.path.dirname(TEST_DIR))
+
+# Absolute path to the Docker composition that provides MongoDB for the tests.
+COMPOSE_FILE = os.path.join(REPO_ROOT, "docker-compose.yml")
+
 
 def input_path(*parts):
     """Return the absolute path to a test input file.

--- a/cyhy/test/testenv.py
+++ b/cyhy/test/testenv.py
@@ -1,0 +1,18 @@
+"""Environment variables and defaults used to configure the test suite."""
+
+# Connection information for the MongoDB instance used by the tests.  These
+# defaults match the instance created by the Docker composition at the root of
+# this repository, which the test suite starts automatically.
+DEFAULT_DB_URI = "mongodb://localhost:27037/test-cyhy"
+DEFAULT_DB_NAME = "test-cyhy"
+
+# Set these to run the tests against a MongoDB instance other than the one
+# provided by the Docker composition.
+DB_NAME_VAR = "CYHY_TEST_DB_NAME"
+DB_URI_VAR = "CYHY_TEST_DB_URI"
+
+# Set this to any value to stop the test suite from starting and stopping the
+# Docker composition itself.  This is useful when a suitable MongoDB instance is
+# already available, for example one provided as a CI service container, or when
+# keeping an instance running between test runs while debugging.
+SKIP_COMPOSE_VAR = "CYHY_TEST_SKIP_COMPOSE"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,18 @@
 # cyhy/test/common_fixtures.py.
 services:
   mongodb:
+    # Allows "docker compose up --wait" to block until MongoDB is ready to
+    # accept connections, so a test run cannot race container startup.
+    healthcheck:
+      interval: 5s
+      retries: 12
+      test:
+        - CMD
+        - mongo
+        - --quiet
+        - --eval
+        - db.adminCommand('ping')
+      timeout: 5s
     # MongoDB 3.6 is used because this project depends on the pymongo 2.x
     # client (see setup.py), which predates newer MongoDB releases.
     image: docker.io/library/mongo:3.6
@@ -21,15 +33,3 @@ services:
       # SSH tunnel to a production database -- already listening on the
       # default port of 27017.
       - "27037:27017"
-    healthcheck:
-      # Allows "docker compose up --wait" to block until MongoDB is ready to
-      # accept connections, so a test run cannot race container startup.
-      test:
-        - CMD
-        - mongo
-        - --quiet
-        - --eval
-        - db.adminCommand('ping')
-      interval: 5s
-      timeout: 5s
-      retries: 12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+---
+# Docker composition providing the MongoDB instance used by the test suite.
+#
+# Bring it up with:
+#   docker compose up --detach
+#
+# ...and tear it down, discarding its data, with:
+#   docker compose down
+#
+# The test suite connects to this instance by default; see
+# cyhy/test/common_fixtures.py.
+services:
+  mongodb:
+    # MongoDB 3.6 is used because this project depends on the pymongo 2.x
+    # client (see setup.py), which predates newer MongoDB releases.
+    image: docker.io/library/mongo:3.6
+    # No volume is configured, so the database is discarded when the container
+    # is removed.  The test suite creates whatever documents it needs.
+    ports:
+      # Publishing on 27037 avoids colliding with a MongoDB instance -- or an
+      # SSH tunnel to a production database -- already listening on the
+      # default port of 27017.
+      - "27037:27017"
+    healthcheck:
+      # Allows "docker compose up --wait" to block until MongoDB is ready to
+      # accept connections, so a test run cannot race container startup.
+      test:
+        - CMD
+        - mongo
+        - --quiet
+        - --eval
+        - db.adminCommand('ping')
+      interval: 5s
+      timeout: 5s
+      retries: 12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # Docker composition providing the MongoDB instance used by the test suite.
 #
 # Bring it up with:
-#   docker compose up --detach
+#   docker compose up --detach --wait
 #
 # ...and tear it down, discarding its data, with:
 #   docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,15 @@
 ---
 # Docker composition providing the MongoDB instance used by the test suite.
 #
-# Bring it up with:
+# The test suite brings this composition up and down on its own, so running the
+# tests requires no manual steps; see cyhy/test/conftest.py.
+#
+# To manage it by hand instead -- see the testing section of the README -- bring
+# it up with:
 #   docker compose up --detach --wait
 #
 # ...and tear it down, discarding its data, with:
 #   docker compose down
-#
-# The test suite connects to this instance by default; see
-# cyhy/test/common_fixtures.py.
 services:
   mongodb:
     # Allows "docker compose up --wait" to block until MongoDB is ready to


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

> [!NOTE]
> This is stacked on #167 and is therefore targeted at that pull request's branch rather than `develop`.  It should be retargeted to `develop` once #167 merges.  Review #167 first; the diff here is only the commits on top of it.

## 🗣 Description ##

Second of the changes for #159.  This removes the remaining manual setup needed to run the test suite, so that `pytest` on its own is the entire procedure:

- **Add a Docker composition** providing the MongoDB instance the database-backed tests need. It uses `mongo:3.6`, publishes port 27037, configures no volume so its data is discarded with the container, and includes a healthcheck.
- **Start and stop it from the test suite.** A session-scoped `dockerc` fixture brings the composition up with `--wait` before the first test that needs MongoDB and takes it down when the session ends. Because it is only instantiated when a test asks for the `database` fixture, the tests that do not use MongoDB still run without Docker.
- **Connect the database fixture directly.** The fixture resolved its connection through `db_from_config()`, which reads the machine-wide `/etc/cyhy/cyhy.conf`. It now uses `db_from_connection()`, defaulting to the composition's instance.
- **Provide escape hatches.** `CYHY_TEST_SKIP_COMPOSE` disables the composition management, and `CYHY_TEST_DB_URI` / `CYHY_TEST_DB_NAME` point the tests at a different instance.
- **Update the README** accordingly.

Following @dav3r's note that cisagov/guacscanner drives its composition from a fixture with [python-on-whales](https://github.com/gabrieldemarmiesse/python-on-whales), this reproduces that behavior with the same fixture shape.  The library itself cannot be used here yet: it requires Python 3.8 or newer, and under Python 2.7 it fails to install at all (`setup.py` uses a Python 3 return annotation). `docker compose` is therefore invoked directly, and the fixture docstring records the intent to switch once this project leaves Python 2.7 behind.

## 💭 Motivation and context ##

Contributes to #159.

Two of the three manual steps that issue calls out were standing up MongoDB by hand and creating an `/etc/cyhy/cyhy.conf` for the tests to read.  Both are now gone.

Beyond convenience, routing the fixture through the machine-wide configuration file was a hazard.  The section named in the fixture had to exist and point somewhere appropriate on every machine, so a mistake in a personal configuration file could aim a destructive test run -- these tests remove documents -- at a real database.  The fixture now defaults to a local, disposable instance and has to be redirected deliberately.

It also removes the reason developers were carrying a local edit to `common_fixtures.py` in their working trees.

## 🧪 Testing ##

Verified on macOS (arm64, Colima):

| Scenario | Result |
| --- | --- |
| `pytest` with no MongoDB running, from the repository root | 192 passed (composition started and stopped automatically) |
| `pytest` with no MongoDB running, from `cyhy/test` | 192 passed |
| `CYHY_TEST_SKIP_COMPOSE=1` against an externally started instance | 49 passed, and the instance survived the run |
| Non-MongoDB tests with `docker` absent from `PATH` | 45 passed |
| `docker` absent from `PATH`, MongoDB tests | Fails with an actionable message naming both escape-hatch variables |
| `CYHY_TEST_DB_URI` pointed at a dead port | All 49 database tests error with `Connection refused`, confirming the override is honored |

Also confirmed that port 27037 is released after each run, that `docker compose config` validates, and that `mongo:3.6` publishes a native `linux/arm64/v8` manifest so no `platform` override is needed on Apple Silicon.

Automatic management adds roughly 7 seconds to a full run (about 3 seconds with MongoDB already up versus about 10 with the composition being started and stopped).

## ➡️ Remaining work for #159 ##

A CI workflow that runs the suite.  `actions/setup-python` no longer offers Python 2.7 on current runners, so it will likely run inside a Python 2.7 container with MongoDB as a service container -- in which case `CYHY_TEST_SKIP_COMPOSE` lets the workflow use the service container instead of a nested composition.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
