### PR TITLE
Add Renovate config for cisagov/cyhy-commander test dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,21 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  // Dependabot keeps handling github-actions + pip; Renovate only manages the
+  // cyhy-commander pin, so restrict it to the custom manager to avoid overlap.
+  customManagers: [
+    {
+      customType: "regex",
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "cisagov/cyhy-commander",
+      managerFilePatterns: ["/^setup\\.py$/"],
+      matchStrings: [
+        "cisagov/cyhy-commander.git@(?<currentValue>\\S+)\",",
+      ],
+      versioningTemplate: "semver-coerced", // handles the leading `v`
+    },
+  ],
+  dependencyDashboard: true,
+  enabledManagers: ["custom.regex"],
+  extends: ["config:recommended"],
+  labels: ["dependencies"],
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
       depNameTemplate: "cisagov/cyhy-commander",
       managerFilePatterns: ["/^setup\\.py$/"],
       matchStrings: [
-        "cisagov/cyhy-commander.git@(?<currentValue>\\S+)\",",
+        "cisagov/cyhy-commander\\.git@(?<currentValue>\\S+)\\\",","
       ],
       versioningTemplate: "semver-coerced", // handles the leading `v`
     },

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
             # directly from GitHub.  It is required by
             # cyhy/test/test_nmap_handler.py, which exercises
             # cyhy_commander.nmap.nmap_handler.
-            "cyhy-commander @ git+https://github.com/cisagov/cyhy-commander.git@develop",
+            "cyhy-commander @ git+https://github.com/cisagov/cyhy-commander.git@v1.2.0",
             "mock >= 2.0.0",
             # pyfakefs 4.0 dropped Python 2.7 support.
             "pyfakefs >= 3.7, < 4.0",


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a Renovate configuration for handling the [cisagov/cyhy-commander](https://github.com/cisagov/cyhy-commander) test dependency that Dependabot cannot.

## 💭 Motivation and context ##

This is vastly superior to keeping the dependency in sync manually, or pulling whatever happens to be at the end of the default branch.

Resolves #168.

## 🧪 Testing ##

All automated tests pass.  I also ran `renovate` locally and verified that it picked up the dependency.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.