### PR TITLE
Run the test suite in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,12 @@ jobs:
       # This project targets Python 2.7, which actions/setup-python no longer
       # offers on current runners, so the tests are run in a container.
       #
+      # The image is pinned by digest so that a run is not affected by the tag
+      # being moved or removed.  Python 2.7 is end of life and 2.7.18 is its
+      # final release, so this pin is not expected to need routine updates.
+      # Note that the Renovate configuration only enables the custom manager for
+      # the cyhy-commander dependency, so this pin is not updated automatically.
+      #
       # CYHY_TEST_SKIP_COMPOSE keeps the test suite from trying to manage the
       # composition started above.  The host network makes that composition's
       # published port reachable at the address the tests use by default, so no
@@ -110,9 +116,14 @@ jobs:
             --rm \
             --volume "$PWD:/src" \
             --workdir /src \
-            docker.io/library/python:2.7 \
+            docker.io/library/python:2.7.18@sha256:cfa62318c459b1fde9e0841c619906d15ada5910d625176e24bf692cf8a2601d \
             bash -Eueo pipefail -x -c \
               "pip install --requirement requirements-test.txt && pytest --verbose"
-      - name: Stop MongoDB
+      # Tearing the composition down is housekeeping, so a failure here must not
+      # turn an otherwise passing run red, nor add noise to a failing one.  Note
+      # that GitHub-hosted runners are discarded after the job regardless; this
+      # matters for self-hosted runners.
+      - continue-on-error: true
         if: always()
+        name: Stop MongoDB
         run: docker compose down

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,118 @@
+---
+name: Test
+
+on:  # yamllint disable-line rule:truthy
+  merge_group:
+    types:
+      - checks_requested
+  # We use the default activity types for the pull_request event as specified here:
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request
+  pull_request:
+
+# Set a default shell for any run steps. The `-Eueo pipefail` sets errtrace,
+# nounset, errexit, and pipefail. The `-x` will print all commands as they are
+# run. Please see the GitHub Actions documentation for more information:
+# https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs
+defaults:
+  run:
+    shell: bash -Eueo pipefail -x {0}
+
+jobs:
+  diagnostics:
+    name: Run diagnostics
+    # This job does not need any permissions
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      # Note that a duplicate of this step must be added at the top of
+      # each job.
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          check_github_status: "true"
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
+          output_workflow_context: "true"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+  test:
+    needs:
+      - diagnostics
+    permissions:
+      # actions/checkout needs this to fetch code
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
+        with:
+          # This functionality is poorly implemented and has been
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-enable this functionality when practical.  See
+          # cisagov/cyhy-core#104 for more details.
+          monitor_permissions: "false"
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - name: Check out the repository
+        uses: actions/checkout@v7
+      # The test suite normally starts this composition itself, but it cannot do
+      # so from inside the container used to run the tests, since that container
+      # has no Docker client.  Start it here instead.
+      - name: Start MongoDB
+        run: docker compose up --detach --wait
+      # This project targets Python 2.7, which actions/setup-python no longer
+      # offers on current runners, so the tests are run in a container.
+      #
+      # CYHY_TEST_SKIP_COMPOSE keeps the test suite from trying to manage the
+      # composition started above.  The host network makes that composition's
+      # published port reachable at the address the tests use by default, so no
+      # connection information has to be supplied here.
+      - name: Run the tests
+        run: |
+          docker run \
+            --env CYHY_TEST_SKIP_COMPOSE=1 \
+            --network host \
+            --rm \
+            --volume "$PWD:/src" \
+            --workdir /src \
+            docker.io/library/python:2.7 \
+            bash -Eueo pipefail -x -c \
+              "pip install --requirement requirements-test.txt && pytest --verbose"
+      - name: Stop MongoDB
+        if: always()
+        run: docker compose down


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->

> [!NOTE]
> This is the fourth pull request in the stack (#167 → #169 → #172 → this one) and is therefore targeted at #172's branch rather than `develop`.  The diff here is a single new workflow file.

## 🗣 Description ##

Final change for #159.  Add a `Test` workflow that runs the test suite on pull requests and merge groups.

The interesting part is Python 2.7.  `actions/setup-python` no longer offers 2.7 on current runners, so the tests run inside a `python:2.7` container while every action still runs on a modern `ubuntu-latest` host.  MongoDB comes from this repository's own Docker composition, started on the runner rather than from inside the test container, which has no Docker client:

- `CYHY_TEST_SKIP_COMPOSE` (added in #169) tells the suite not to manage the composition itself.
- The container is given the host network, so the composition's published port is reachable at the address the tests already use by default. No connection information has to be passed in.
- `Stop MongoDB` runs with `if: always()` so the composition is torn down even when the tests fail.

## 💭 Motivation and context ##

Contributes to #159, which asked for testing to work out of the box.  Nothing currently runs the suite automatically -- the only existing workflow builds the Docker image -- so the work in #167 and #169 could regress without anyone noticing.

## 🧪 Testing ##

The workflow itself cannot run until this is opened, so the configuration it encodes was validated locally first, in a `python:2.7` container using the same environment variable and networking arrangement:

| Check | Result |
| --- | --- |
| `pip install --requirement requirements-test.txt` in `python:2.7` | Succeeds |
| Full suite, container attached to the composition network by service name | 192 passed |
| Full suite, container on the host network using the default URI (what this workflow does) | 192 passed |
| Same, with the `cyhy-commander` `v1.2.0` pin from #172 | 192 passed, and `cyhy_commander` imports |
| `python:2.7` toolchain versions | Python 2.7.18, pip 20.0.2, setuptools 44.1.0 -- all within the Python 2.7-compatible bounds, and pip is new enough for the PEP 508 direct reference |

Two failures surfaced during that work and both were artifacts of my local machine rather than problems with this configuration.  They are worth recording because they would otherwise look alarming:

1. **PyYAML failed to build** with `AttributeError: cython_sources`. This happens only on arm64, where there is no `cp27` wheel for PyYAML, so it builds from source and picks up Cython 3. Runners are amd64, where a `cp27` manylinux wheel is used and nothing is built. Verified by re-running with `--platform linux/amd64`.
2. **`ImportError: No module named Random.random`** from `cyhy/db/crypto.py`. Mounting a macOS directory into a Linux container yields case-insensitive lookups, so Python 2's implicit relative import resolved `import Crypto` to our own `crypto.py`. Runner checkouts are on a case-sensitive filesystem. Verified by piping the source in rather than bind-mounting it.

Because of the second point, the local runs delivered the source over stdin instead of bind-mounting it.  The workflow bind-mounts the workspace, which is correct on a Linux runner.  That is the one difference between what was verified locally and what runs here, and it is the reason it could not be eliminated locally.

The YAML was confirmed to parse and to produce the intended triggers, jobs, and steps.

## ➡️ A note on versioning ##

No version bump is included.  Across all four pull requests in the stack, nothing that ships changed: the cumulative diff against `develop` touches only test code, CI configuration, the Docker composition, documentation, and packaging metadata, with no files under `bin/`, `cyhy/core/`, `cyhy/db/`, or `cyhy/util/`.  The new test modules are not distributed either, since `cyhy/test` has no `__init__.py` and `find_packages()` therefore yields only `cyhy`, `cyhy.core`, `cyhy.db`, and `cyhy.util`.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.