### PR TITLE
Remove extraneous backslash from Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
       depNameTemplate: "cisagov/cyhy-commander",
       managerFilePatterns: ["/^setup\\.py$/"],
       matchStrings: [
-        "cisagov/cyhy-commander\\.git@(?<currentValue>\\S+)\\\",","
+        "cisagov/cyhy-commander\\.git@(?<currentValue>\\S+)\","
       ],
       versioningTemplate: "semver-coerced", // handles the leading `v`
     },


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes a typo in the Renovate configuration.  I'm not sure how this was missed when I tested previously; I must have made a mistake.

## 💭 Motivation and context ##

If we want it to work we have to fix it.

## 🧪 Testing ##

All automated tests pass.  I also ran `renovate` locally to confirm the fix.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.