### PR TITLE
Fix latent crashes in cyhy-domain remove and move commands

### DIFF
--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -179,6 +179,26 @@ def remove(db, owner, domains):
             print ("\t%s" % d)
         sys.exit(-1)
 
+    # Remove domains from any HostDocs that have them.  This is done before the
+    # request document is saved so that a failure here cannot leave the domains
+    # removed from the request document but still attached to host documents,
+    # which would require manual recovery (the check above would reject a
+    # re-run).
+    for d in domains:
+        count = 0
+        for h in db.HostDoc.get_by_hostname(d):
+            # Filter on hostname alone, which is what get_by_hostname selected
+            # on.  The owner recorded in a HostDoc hostnames entry can lag the
+            # request documents, since 'cyhy-domain move' does not touch HostDocs
+            # and cyhy-domainsync reconciles them on its next run.  Removing an
+            # exact {hostname, owner} dict would raise ValueError in that
+            # window, and would also break if the entry ever grows a field.
+            h["hostnames"] = [i for i in h["hostnames"] if i["hostname"] != d]
+            h.save()
+            count += 1
+        if count:
+            print "Removed %s from %d hosts documents" % (d, count)
+
     for d in domains:
         request["hostnames"].remove(d)
     request.save()
@@ -186,16 +206,6 @@ def remove(db, owner, domains):
     print "Domains removed from %s (%s):" % (request["agency"]["name"], owner)
     for d in domains:
         print ("\t%s" % d)
-
-    # Remove domains from any HostDocs that have them
-    for d in domains:
-        count = 0
-        for h in db.HostDoc.get_by_hostname(d):
-            h["hostnames"].remove({"hostname": d, "owner": owner})
-            h.save()
-            count += 1
-        if count:
-            print "Removed %s from %d hosts documents" % (d, count)
 
     # Close open tickets referencing the removed domains
     ticket_closing_time = util.utcnow()

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -386,7 +386,7 @@ def move(db, orig_owner, new_owner, domains_to_move):
 
 
 def main():
-    args = docopt(__doc__, version="v1.3.1")
+    args = docopt(__doc__, version="v1.3.2")
 
     db = database.db_from_config(args["--section"], args["--config-file"])
 

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -167,7 +167,7 @@ def remove(db, owner, domains):
 
     unowned_domains = []
     for d in domains:
-        if d not in request.get("hostnames"):
+        if d not in request.get("hostnames", []):
             unowned_domains.append(d)
 
     if unowned_domains:
@@ -334,7 +334,7 @@ def move(db, orig_owner, new_owner, domains_to_move):
             print "ERROR: Organization %s not found in DB" % org
             sys.exit(-1)
 
-    orig_owner_domains = set(orig_owner_request.get("hostnames"))
+    orig_owner_domains = set(orig_owner_request.get("hostnames", []))
     domains_not_in_orig_owner = set(domains_to_move) - orig_owner_domains
     if domains_not_in_orig_owner:
         print "\nERROR - The following domains are NOT owned by %s (%s):" % (
@@ -355,7 +355,7 @@ def move(db, orig_owner, new_owner, domains_to_move):
     orig_owner_request["hostnames"] = sorted(orig_owner_domains - set(domains_to_move))
     # Add the domains_to_move to new_owner's request doc
     new_owner_request["hostnames"] = sorted(
-        set(new_owner_request.get("hostnames")) | set(domains_to_move)
+        set(new_owner_request.get("hostnames", [])) | set(domains_to_move)
     )
 
     # Save both request docs

--- a/bin/cyhy-domain
+++ b/bin/cyhy-domain
@@ -323,8 +323,9 @@ def change_ticket_owner(db, orig_owner, new_owner, reason, domains):
         safe=True,
         upsert=False,
     )
+    modified = result.get("nModified", 0) if result else 0
     print "%d tickets documents modified (%s -> %s)" % (
-        result["nModified"],
+        modified,
         orig_owner,
         new_owner,
     )

--- a/cyhy/__init__.py
+++ b/cyhy/__init__.py
@@ -6,7 +6,7 @@ __path__ = extend_path(__path__, __name__)
 import sys as _sys
 
 #: Version info (major, minor, maintenance, status)
-VERSION = (1, 3, 3)
+VERSION = (1, 3, 4)
 STATUS = ""
 __version__ = "%d.%d.%d" % VERSION[0:3] + STATUS
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cyhy-core",
-    version="1.3.3",
+    version="1.3.4",
     author="Mark Feldhousen Jr.",
     author_email="mark.feldhousen@cisa.dhs.gov",
     packages=find_packages(),


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->

# Fix latent crashes in cyhy-domain remove and move commands <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Three independent latent crashes in `bin/cyhy-domain` are fixed here, one per commit, followed by the two version bumps.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

`3d626db` defaults a missing `hostnames` key to an empty list in the three places that assumed it was present. A request document has no `hostnames` key until its organization is assigned at least one domain: the field is declared in `RequestDoc.structure` but absent from both `required_fields` and `default_values`, and mongokit skips skeleton generation for documents loaded from the database. Passing the result of `.get("hostnames")` to `set()` or using it as the right operand of `in` therefore raised `TypeError` on a `NoneType`.

`19c4b3b` stops removing an exact `{hostname, owner}` dictionary from a host document's `hostnames` list and filters on the hostname alone, which is what `HostDoc.get_by_hostname` already selected on and what `cyhy-domainsync` uses on its own removal path. The same commit saves the request document *after* the host documents rather than before, so a failure in that loop no longer leaves partially applied state.

`5052488` reads `nModified` from the ticket owner update response using the guarded form already used for the `latest` flag updates in `remove()`, instead of indexing it directly.

`59326ff` and `cd42441` bump `cyhy-domain` from `v1.3.1` to `v1.3.2` and `cyhy-core` from `1.3.3` to `1.3.4` respectively, the latter in both `setup.py` and `cyhy/__init__.py`. Note that this repository has no `bump_version` script, so both bumps were made by hand, matching the convention in `b4e669c` and `c79b08e`.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

A member of the CyHy Ops team contacted us with an error traceback when they attempted to move a domain from one entity to another entity that never had any domains before.  Since that entity had no `hostnames` field in their `RequestDoc`, the `cyhy-domain move` command failed, which led to the fix in `3d626db`.

Each of these turns a condition the code already handles deliberately into a traceback. The two `TypeError` cases replace diagnostics the script was written to print: `remove()` has a "does not own the following domains" error and `move()` has a "domains are NOT owned by" error, and neither could ever be reached for an organization that had never been assigned a domain.

The host document case is the most damaging, because the owner recorded in a `HostDoc` `hostnames` entry can legitimately disagree with the request documents. `move()` rewrites the request documents and the ticket owners but never touches host documents; `cyhy-domainsync` reconciles the two on its next run, and it has an explicit branch for updating a changed owner. Removing a domain from the new owner inside that window raised `ValueError` *after* the request document had been saved and reported as updated, leaving the domain gone from the request but still attached to its host documents, with tickets and `latest` flags never processed. A re-run then failed the ownership check, so recovery required manual intervention. Reordering the saves makes the command safe to re-run.

Note that `move()` still leaves host documents stale until `cyhy-domainsync` next runs; this PR makes `remove()` tolerant of that lag rather than eliminating it.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Verified locally on macOS against Python 2.7.18, pymongo 2.9.5, and mongokit, which is the environment `setup.py` pins. `python -m py_compile bin/cyhy-domain` passes at every commit in this branch, and `python -c "import cyhy; print(cyhy.__version__)"` reports `1.3.4`.

The list filtering change was checked in isolation against three input shapes: an entry whose owner matches, an entry carrying a stale owner, and an entry with an additional field. The first produces output identical to the old `.remove()` call; the other two raised `ValueError` before and now succeed.

There is no automated coverage for `bin/cyhy-domain`, and the existing suite brings up its own MongoDB via Docker Compose and does not touch this script, so it neither covers nor is affected by these changes. I did not add tests, since doing so would mean building the first test harness for the `bin` scripts, which is issue #57 territory and well beyond this fix.

A reviewer can exercise all three paths against a scratch database. For the `TypeError` cases, pick an organization with no `hostnames` key and run `cyhy-domain remove ORG foo.gov` and `cyhy-domain move ORG OTHER_ORG foo.gov`; both should print their intended ownership error and exit rather than traceback. For the `ValueError` case, run `cyhy-domain move ORG_A ORG_B some.gov` and then `cyhy-domain remove ORG_B some.gov` *before* `cyhy-domainsync` runs again; the removal should complete and report the affected host documents.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.
-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release (necessary if and only if the version was bumped).
